### PR TITLE
Publish to maven

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -77,8 +77,8 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
-      - name: Build with maven
-        run: mvn package -DskipTests
+      - name: Publish with Maven
+        run: mvn -ntp --settings settings.xml deploy -DskipTests -Dstargate-snapshot-repository-url=${{ secrets.stargate_dev_snapshot_repository_url }}
       - run: sudo apt-get install -y awscli
       - name: Upload to S3
         run: aws s3 cp target/SecretManager.jar s3://gg-evergreen-releases/${{github.repository}}/${{github.ref}}/evergreen-secret-manager-${{github.sha}}.jar

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,20 @@
             <url>https://d10d248laylpoq.cloudfront.net</url>
         </repository>
     </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>maven-snapshots</id>
+            <name>Maven snapshots</name>
+            <layout>default</layout>
+            <url>https://repository.apache.org/content/repositories/snapshots/</url>
+        </pluginRepository>
+        <pluginRepository>
+            <id>yle-public</id>
+            <name>Yle public repository</name>
+            <url>https://d2x444wtt5plvm.cloudfront.net/release</url>
+            <layout>default</layout>
+        </pluginRepository>
+    </pluginRepositories>
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -32,6 +46,13 @@
         </dependencies>
     </dependencyManagement>
     <build>
+        <extensions>
+            <extension>
+                <groupId>fi.yle.tools</groupId>
+                <artifactId>aws-maven</artifactId>
+                <version>1.4.2</version>
+            </extension>
+        </extensions>
         <plugins>
             <plugin>
                 <groupId>org.jacoco</groupId>


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Publish artifacts to maven

**Why is this change necessary:**
lambda-manager can directly call get secrets API bypassing the API layer to support v1 style API

**How was this change tested:**
ran existing tests locally 

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
