### PR TITLE
Add support for v1 style secret fetch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,12 +104,12 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.89</minimum>
+                                            <minimum>0.90</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.83</minimum>
+                                            <minimum>0.88</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/src/main/java/com/aws/greengrass/secretmanager/AWSSecretClient.java
+++ b/src/main/java/com/aws/greengrass/secretmanager/AWSSecretClient.java
@@ -70,7 +70,7 @@ public class AWSSecretClient {
         }
     }
 
-    private void validateResponse(GetSecretValueResponse response) throws IllegalArgumentException {
+    private void validateResponse(GetSecretValueResponse response) {
         String errorStr = "Invalid secret response, %s is missing";
         if (Utils.isEmpty(response.versionId())) {
             throw new IllegalArgumentException(String.format(errorStr, "version Id"));
@@ -92,7 +92,7 @@ public class AWSSecretClient {
         }
     }
 
-    private void validateInput(GetSecretValueRequest request) throws IllegalArgumentException {
+    private void validateInput(GetSecretValueRequest request) {
         if (Utils.isEmpty(request.secretId())) {
             throw new IllegalArgumentException("invalid secret request, secret id is required");
         }

--- a/src/main/java/com/aws/greengrass/secretmanager/SecretManager.java
+++ b/src/main/java/com/aws/greengrass/secretmanager/SecretManager.java
@@ -15,6 +15,7 @@ import com.aws.greengrass.secretmanager.crypto.PemFile;
 import com.aws.greengrass.secretmanager.crypto.RSAMasterKey;
 import com.aws.greengrass.secretmanager.exception.SecretCryptoException;
 import com.aws.greengrass.secretmanager.exception.SecretManagerException;
+import com.aws.greengrass.secretmanager.exception.v1.GetSecretException;
 import com.aws.greengrass.secretmanager.kernel.KernelClient;
 import com.aws.greengrass.secretmanager.model.AWSSecretResponse;
 import com.aws.greengrass.secretmanager.model.SecretConfiguration;
@@ -24,12 +25,14 @@ import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
 
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -117,42 +120,46 @@ public class SecretManager {
                 GetSecretValueRequest request = GetSecretValueRequest.builder().secretId(secretArn)
                         .versionStage(label).build();
                 try {
-                    GetSecretValueResponse result = secretClient.getSecret(request);
-                    // Save the secrets to local store for offline access
-                    String encodedSecretString = null;
-                    if (result.secretString() != null) {
-                        byte[] encryptedSecretString = crypter.encrypt(
-                                result.secretString().getBytes(StandardCharsets.UTF_8),
-                                result.arn());
-                        encodedSecretString = Base64.getEncoder().encodeToString(encryptedSecretString);
-                    }
-                    String encodedSecretBinary = null;
-                    if (result.secretBinary() != null) {
-                        byte[] encryptedSecretBinary = crypter.encrypt(
-                                result.secretBinary().asByteArray(),
-                                result.arn());
-                        encodedSecretBinary = Base64.getEncoder().encodeToString(encryptedSecretBinary);
-                    }
-                    // reuse all fields except the secret value, replace secret value with encrypted value
-                    AWSSecretResponse encryptedResult = AWSSecretResponse.builder()
-                            .encryptedSecretString(encodedSecretString)
-                            .encryptedSecretBinary(encodedSecretBinary)
-                            .name(result.name())
-                            .arn(result.arn())
-                            .createdDate(result.createdDate().toEpochMilli())
-                            .versionId(result.versionId())
-                            .versionStages(result.versionStages())
-                            .build();
+                    AWSSecretResponse encryptedResult = fetchAndEncryptAWSResponse(request);
                     downloadedSecrets.add(encryptedResult);
                 } catch (Throwable e) {
                     logger.atWarn().kv("Secret ", secretArn).log("Could not fetch secret from cloud", e);
-                    continue;
                 }
             }
         }
         secretDao.saveAll(SecretDocument.builder().secrets(downloadedSecrets).build());
         // Once the secrets are finished downloading, load it locally
         loadSecretsFromLocalStore();
+    }
+
+    private AWSSecretResponse fetchAndEncryptAWSResponse(GetSecretValueRequest request)
+            throws SecretCryptoException, SecretManagerException {
+        GetSecretValueResponse result = secretClient.getSecret(request);
+        // Save the secrets to local store for offline access
+        String encodedSecretString = null;
+        if (result.secretString() != null) {
+            byte[] encryptedSecretString = crypter.encrypt(
+                    result.secretString().getBytes(StandardCharsets.UTF_8),
+                    result.arn());
+            encodedSecretString = Base64.getEncoder().encodeToString(encryptedSecretString);
+        }
+        String encodedSecretBinary = null;
+        if (result.secretBinary() != null) {
+            byte[] encryptedSecretBinary = crypter.encrypt(
+                    result.secretBinary().asByteArray(),
+                    result.arn());
+            encodedSecretBinary = Base64.getEncoder().encodeToString(encryptedSecretBinary);
+        }
+         // reuse all fields except the secret value, replace secret value with encrypted value
+         return AWSSecretResponse.builder()
+                .encryptedSecretString(encodedSecretString)
+                .encryptedSecretBinary(encodedSecretBinary)
+                .name(result.name())
+                .arn(result.arn())
+                .createdDate(result.createdDate().toEpochMilli())
+                .versionId(result.versionId())
+                .versionStages(result.versionStages())
+                .build();
     }
 
     /**
@@ -171,10 +178,10 @@ public class SecretManager {
     /*
     * Cache holds multiple references of the secret with different keys for fast lookup
     * Secret with arn1, version V1, labels as L1 and L2 is loaded as 4 entries
-    * arn1 -> secret
-    * arn1:v1 -> secret
-    * arn1:l1 -> secret
-    * arn1:l2 -> secret
+    * arn1 -> secret1
+    * arn1:v1 -> secret2
+    * arn1:l1 -> secret3
+    * arn1:l2 -> secret4
     */
     private void loadCache(AWSSecretResponse awsSecretResponse) throws SecretManagerException {
         GetSecretValueResponse decryptedResponse = null;
@@ -219,6 +226,110 @@ public class SecretManager {
         }
     }
 
+    private GetSecretValueResponse getSecret(String secretId, String versionId, String versionStage)
+        throws GetSecretException {
+        String secretNotFoundErr = "Secret not found ";
+        String arn = secretId;
+        if (Utils.isEmpty(secretId)) {
+            throw new GetSecretException(400, "SecretId absent in the request");
+        }
+        // normalize name to arn
+        if (!Pattern.matches(VALID_SECRET_ARN_PATTERN, secretId)) {
+            if (!nametoArnMap.containsKey(secretId)) {
+                throw new GetSecretException(404, secretNotFoundErr + secretId);
+            }
+            arn = nametoArnMap.get(secretId);
+        }
+
+        // We cannot just return the value, as same arn can have multiple labels associated to it.
+        if (!cache.containsKey(arn)) {
+            throw new GetSecretException(404, secretNotFoundErr + secretId);
+        }
+
+        // Both are optional
+        if (!Utils.isEmpty(versionId) && !Utils.isEmpty(versionStage)) {
+            throw new GetSecretException(400,
+                    "Both versionId and Stage are set in the request");
+        }
+
+        if (!Utils.isEmpty(versionId)) {
+            if (!cache.containsKey(arn + versionId)) {
+                String errorStr = "Version Id " + versionId + " not found for secret " + secretId;
+                throw new GetSecretException(404, errorStr);
+            }
+            return cache.get(arn + versionId);
+        }
+
+        if (!Utils.isEmpty(versionStage)) {
+            if (!cache.containsKey(arn + versionStage)) {
+                String errorStr = "Version stage " + versionStage + " not found for secret " + secretId;
+                throw new GetSecretException(404, errorStr);
+            }
+            return cache.get(arn + versionStage);
+        }
+        // If none of the label and version are specified then return LATEST_LABEL
+        if (!cache.containsKey((arn + LATEST_LABEL))) {
+            throw new GetSecretException(404, secretNotFoundErr + secretId);
+        }
+        return cache.get(arn + LATEST_LABEL);
+    }
+
+    /**
+     * Get v1 style secret, to support lambdas using v1 SDK to get secrets.
+     * @param request       v1 sdk request from lambda to get secret
+     * @return secret       v1 sdk response containing secret and metadata
+     * @throws GetSecretException    when there is any issue accessing secret
+     */
+    public com.aws.greengrass.secretmanager.model.v1.GetSecretValueResult
+        getSecret(com.aws.greengrass.secretmanager.model.v1.GetSecretValueRequest request) throws GetSecretException {
+            GetSecretValueResponse secretResponse = getSecret(request.getSecretId(), request.getVersionId(),
+                    request.getVersionStage());
+            return translateModeltov1(secretResponse);
+    }
+
+    /**
+     * Get a secret. Secrets are stored in memory and only loaded from disk on reload or when synced from cloud.
+     * @param request IPC request from kernel to get secret
+     * @return secret IPC response containing secret and metadata
+     */
+    public com.aws.greengrass.ipc.services.secret.GetSecretValueResult
+        getSecret(com.aws.greengrass.ipc.services.secret.GetSecretValueRequest request) {
+        try {
+            GetSecretValueResponse secretResponse = getSecret(request.getSecretId(), request.getVersionId(),
+                    request.getVersionStage());
+            return translateModeltoIpc(secretResponse);
+        } catch (GetSecretException e) {
+            return buildIPCErrorResponse(SecretResponseStatus.InvalidRequest, e.getMessage());
+        }
+    }
+
+    private com.aws.greengrass.ipc.services.secret.GetSecretValueResult
+        buildIPCErrorResponse(SecretResponseStatus status, String error) {
+        return com.aws.greengrass.ipc.services.secret.GetSecretValueResult
+                .builder()
+                .responseStatus(status)
+                .errorMessage(error)
+                .build();
+    }
+
+    private com.aws.greengrass.secretmanager.model.v1.GetSecretValueResult
+        translateModeltov1(GetSecretValueResponse response) {
+        byte[] secretBinary = null;
+        if (response.secretBinary() != null) {
+            secretBinary = response.secretBinary().asByteArray();
+        }
+        return com.aws.greengrass.secretmanager.model.v1.GetSecretValueResult
+                .builder()
+                .arn(response.arn())
+                .name(response.name())
+                .secretString(response.secretString())
+                .secretBinary(ByteBuffer.wrap(secretBinary))
+                .versionId(response.versionId())
+                .versionStages(response.versionStages())
+                .createdDate(Date.from(response.createdDate()))
+                .build();
+    }
+
     private com.aws.greengrass.ipc.services.secret.GetSecretValueResult
         translateModeltoIpc(GetSecretValueResponse response) {
         byte[] secretBinary = null;
@@ -233,72 +344,6 @@ public class SecretManager {
                 .versionId(response.versionId())
                 .versionStages(response.versionStages())
                 .responseStatus(SecretResponseStatus.Success)
-                .build();
-    }
-
-    /**
-     * Get a secret. Secrets are stored in memory and only loaded from disk on reload or when synced from cloud.
-     * @param request IPC request from kernel to get secret
-     * @return secret IPC response containing secret and metadata
-     */
-    public com.aws.greengrass.ipc.services.secret.GetSecretValueResult
-        getSecret(com.aws.greengrass.ipc.services.secret.GetSecretValueRequest request) {
-
-        // TODO: Add support for v1 IPC
-        String secretId = request.getSecretId();
-        String arn = secretId;
-        if (Utils.isEmpty(secretId)) {
-            return buildErrorResponse(SecretResponseStatus.InvalidRequest, "SecretId absent in the request");
-        }
-        // normalize name to arn
-        if (!Pattern.matches(VALID_SECRET_ARN_PATTERN, secretId)) {
-            if (!nametoArnMap.containsKey(secretId)) {
-                return buildErrorResponse(SecretResponseStatus.InvalidRequest, "Secret not found " + secretId);
-            }
-            arn = nametoArnMap.get(secretId);
-        }
-
-        // We cannot just return the value, as same arn can have multiple labels associated to it.
-        if (!cache.containsKey(arn)) {
-            return buildErrorResponse(SecretResponseStatus.InvalidRequest, "Secret not found " + secretId);
-        }
-
-        // Both are optional
-        String versionId = request.getVersionId();
-        String versionStage = request.getVersionStage();
-        if (!Utils.isEmpty(versionId) && !Utils.isEmpty(versionStage)) {
-            return buildErrorResponse(SecretResponseStatus.InvalidRequest,
-                    "Both versionId and Stage are set in the request");
-        }
-
-        if (!Utils.isEmpty(versionId)) {
-            if (!cache.containsKey(arn + versionId)) {
-                String errorStr = "Version Id " + versionId + " not found for secret " + secretId;
-                return buildErrorResponse(SecretResponseStatus.InvalidRequest, errorStr);
-            }
-            return translateModeltoIpc(cache.get(arn + versionId));
-        }
-
-        if (!Utils.isEmpty(versionStage)) {
-            if (!cache.containsKey(arn + versionStage)) {
-                String errorStr = "Version stage " + versionStage + " not found for secret " + secretId;
-                return buildErrorResponse(SecretResponseStatus.InvalidRequest, errorStr);
-            }
-            return translateModeltoIpc(cache.get(arn + versionStage));
-        }
-        // If none of the label and version are specified then return LATEST_LABEL
-        if (!cache.containsKey((arn + LATEST_LABEL))) {
-            return buildErrorResponse(SecretResponseStatus.InvalidRequest, "Secret not found " + secretId);
-        }
-        return translateModeltoIpc(cache.get(arn + LATEST_LABEL));
-    }
-
-    private com.aws.greengrass.ipc.services.secret.GetSecretValueResult
-        buildErrorResponse(SecretResponseStatus status, String error) {
-        return com.aws.greengrass.ipc.services.secret.GetSecretValueResult
-                .builder()
-                .responseStatus(status)
-                .errorMessage(error)
                 .build();
     }
 }

--- a/src/main/java/com/aws/greengrass/secretmanager/crypto/PemFile.java
+++ b/src/main/java/com/aws/greengrass/secretmanager/crypto/PemFile.java
@@ -79,11 +79,10 @@ public class PemFile {
      * @throws SecretCryptoException when there is error generating the key from file
      */
     public static PublicKey generatePublicKeyFromCert(String path) throws SecretCryptoException {
-        try {
-            FileInputStream fileInputStream = new FileInputStream(path);
+        try (FileInputStream fileInputStream = new FileInputStream(path)) {
             CertificateFactory cf = CertificateFactory.getInstance("X.509", JCE_PROVIDER);
-            X509Certificate cert = (X509Certificate)cf.generateCertificate(fileInputStream);
-            PublicKey publicKey =  cert.getPublicKey();
+            X509Certificate cert = (X509Certificate) cf.generateCertificate(fileInputStream);
+            PublicKey publicKey = cert.getPublicKey();
             X509EncodedKeySpec x509EncodedKeySpec = new X509EncodedKeySpec(publicKey.getEncoded());
             KeyFactory keyFactory = KeyFactory.getInstance(RSA_ALGO, JCE_PROVIDER);
             return keyFactory.generatePublic(x509EncodedKeySpec);

--- a/src/main/java/com/aws/greengrass/secretmanager/exception/v1/GetSecretException.java
+++ b/src/main/java/com/aws/greengrass/secretmanager/exception/v1/GetSecretException.java
@@ -1,0 +1,23 @@
+package com.aws.greengrass.secretmanager.exception.v1;
+
+import lombok.Getter;
+
+public class GetSecretException extends Exception {
+    @Getter
+    private final int status;
+
+    public GetSecretException(int status, String err) {
+        super(err);
+        this.status = status;
+    }
+
+    public GetSecretException(int status, Exception err) {
+        super(err);
+        this.status = status;
+    }
+
+    public GetSecretException(int status, String err, Exception e) {
+        super(err, e);
+        this.status = status;
+    }
+}

--- a/src/main/java/com/aws/greengrass/secretmanager/kernel/KernelClient.java
+++ b/src/main/java/com/aws/greengrass/secretmanager/kernel/KernelClient.java
@@ -31,11 +31,6 @@ public class KernelClient {
         return Coerce.toString(deviceConfiguration.getCertificateFilePath());
     }
 
-    public boolean isAuthorized() {
-        // TODO: integrate with authorization service
-        return true;
-    }
-
     public Configuration getConfig() {
         return kernel.getConfig();
     }

--- a/src/main/java/com/aws/greengrass/secretmanager/model/v1/GetSecretValueError.java
+++ b/src/main/java/com/aws/greengrass/secretmanager/model/v1/GetSecretValueError.java
@@ -1,0 +1,25 @@
+package com.aws.greengrass.secretmanager.model.v1;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder(toBuilder = true)
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class GetSecretValueError extends Exception {
+    /**
+     * Status code for the error response.
+     */
+    @JsonProperty("Status")
+    private int status;
+
+    /**
+     * Error message for the error response.
+     */
+    @JsonProperty("Message")
+    private String message;
+}

--- a/src/main/java/com/aws/greengrass/secretmanager/model/v1/GetSecretValueRequest.java
+++ b/src/main/java/com/aws/greengrass/secretmanager/model/v1/GetSecretValueRequest.java
@@ -1,0 +1,29 @@
+package com.aws.greengrass.secretmanager.model.v1;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder(toBuilder = true)
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class GetSecretValueRequest {
+    /**
+     * The unique identifier of the secret.
+     */
+    @JsonProperty("SecretId")
+    private String secretId;
+    /**
+     * The unique identifier of the secret version.
+     */
+    @JsonProperty("VersionId")
+    private String versionId;
+    /**
+     * The staging label attached to the secret version.
+     */
+    @JsonProperty("VersionStage")
+    private String versionStage;
+}

--- a/src/main/java/com/aws/greengrass/secretmanager/model/v1/GetSecretValueResult.java
+++ b/src/main/java/com/aws/greengrass/secretmanager/model/v1/GetSecretValueResult.java
@@ -1,0 +1,60 @@
+package com.aws.greengrass.secretmanager.model.v1;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.Date;
+
+@Builder(toBuilder = true)
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class GetSecretValueResult {
+    /**
+     * ARN of the secret.
+     */
+    @JsonProperty("ARN")
+    private String arn;
+
+    /**
+     * The date and time that this version of the secret was created.
+     */
+    @JsonProperty("CreatedDate")
+    private Date createdDate;
+
+    /**
+     * The friendly name of the secret.
+     */
+    @JsonProperty("Name")
+    private String name;
+
+    /**
+     * The decrypted part of the protected secret information that was originally provided as binary data
+     * in the form of a byte array.
+     */
+    @JsonProperty("SecretBinary")
+    private ByteBuffer secretBinary;
+
+    /**
+     * The decrypted part of the protected secret information that was originally provided as a string.
+     */
+    @JsonProperty("SecretString")
+    private String secretString;
+
+    /**
+     * The unique identifier of this version of the secret.
+     */
+    @JsonProperty("VersionId")
+    private String versionId;
+
+    /**
+     * A list of all of the staging labels currently attached to this version of the secret.
+     */
+    @JsonProperty("VersionStages")
+    private Collection<String> versionStages;
+}

--- a/src/test/java/com/aws/greengrass/secretmanager/SecretManagerServiceTest.java
+++ b/src/test/java/com/aws/greengrass/secretmanager/SecretManagerServiceTest.java
@@ -13,13 +13,17 @@ import com.aws.greengrass.ipc.ConnectionContext;
 import com.aws.greengrass.ipc.common.FrameReader;
 import com.aws.greengrass.ipc.services.common.ApplicationMessage;
 import com.aws.greengrass.ipc.services.common.IPCUtil;
+import com.aws.greengrass.ipc.services.secret.GetSecretValueRequest;
 import com.aws.greengrass.ipc.services.secret.GetSecretValueResult;
 import com.aws.greengrass.ipc.services.secret.SecretClientOpCodes;
 import com.aws.greengrass.ipc.services.secret.SecretResponseStatus;
 import com.aws.greengrass.lifecyclemanager.GreengrassService;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.secretmanager.exception.SecretManagerException;
+import com.aws.greengrass.secretmanager.exception.v1.GetSecretException;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.cbor.databind.CBORMapper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,7 +36,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
@@ -40,19 +46,25 @@ import java.util.concurrent.TimeUnit;
 
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
 public class SecretManagerServiceTest {
+    private static final ObjectMapper CBOR_MAPPER = new CBORMapper();
     private final String SECRET_ID = "secret";
+    private final String SECRET_NAME = "secretName";
     private final String VERSION_ID = "id";
     private final String VERSION_LABEL = "label";
     private final String CURRENT_LABEL = "AWSCURRENT";
@@ -147,7 +159,7 @@ public class SecretManagerServiceTest {
                 .build();
 
 
-        when(mockSecretManager.getSecret(any())).thenReturn(mockSecretResponse1);
+        when(mockSecretManager.getSecret(any(GetSecretValueRequest.class))).thenReturn(mockSecretResponse1);
         when(mockContext.getServiceName()).thenReturn("mockService");
         when(mockAuthorizationHandler.isAuthorized(stringCaptor.capture(), permissionCaptor.capture())).thenReturn(true);
 
@@ -168,6 +180,164 @@ public class SecretManagerServiceTest {
         verify(mockAuthorizationHandler, atLeastOnce()).registerComponent(SecretManagerService.SECRET_MANAGER_SERVICE_NAME,
                 new HashSet<>(Arrays.asList(SecretManagerService.SECRETS_AUTHORIZATION_OPCODE)));
     }
+
+    @Test
+    void GIVEN_secret_service_WHEN_v1_get_called_THEN_correct_response_returned() throws Exception {
+        startKernelWithConfig("config.yaml", State.RUNNING);
+        final String secretValue = "secretValue";
+        final String serviceName = "mockService";
+        final Date currentTime = Date.from(Instant.now());
+        com.aws.greengrass.secretmanager.model.v1.GetSecretValueResult expectedResponse =
+                com.aws.greengrass.secretmanager.model.v1.GetSecretValueResult.builder()
+                        .secretString(secretValue)
+                        .arn(SECRET_ID)
+                        .name(SECRET_NAME)
+                        .versionId(VERSION_ID)
+                        .versionStages(Arrays.asList(new String[]{CURRENT_LABEL, VERSION_LABEL}))
+                        .createdDate(currentTime)
+                        .build();
+
+
+        when(mockSecretManager.getSecret(any(com.aws.greengrass.secretmanager.model.v1.GetSecretValueRequest.class)))
+                .thenReturn(expectedResponse);
+        when(mockAuthorizationHandler.isAuthorized(stringCaptor.capture(), permissionCaptor.capture())).thenReturn(true);
+
+        com.aws.greengrass.secretmanager.model.v1.GetSecretValueRequest request =
+                com.aws.greengrass.secretmanager.model.v1.GetSecretValueRequest.builder()
+                        .secretId(SECRET_ID)
+                        .versionId(VERSION_ID)
+                        .build();
+        byte[] byteRequest = CBOR_MAPPER.writeValueAsBytes(request);
+        byte[] response = kernel.getContext().get(SecretManagerService.class).getSecret(serviceName, byteRequest);
+
+        com.aws.greengrass.secretmanager.model.v1.GetSecretValueResult actualResponse =
+                CBOR_MAPPER.readValue(response,
+                        com.aws.greengrass.secretmanager.model.v1.GetSecretValueResult.class);
+
+        assertEquals(SECRET_ID, actualResponse.getArn());
+        assertEquals(SECRET_NAME, actualResponse.getName());
+        assertEquals(VERSION_ID, actualResponse.getVersionId());
+        assertEquals(secretValue, actualResponse.getSecretString());
+        assertThat(actualResponse.getVersionStages(), hasItem(CURRENT_LABEL));
+        assertThat(actualResponse.getVersionStages(), hasItem(VERSION_LABEL));
+        assertEquals(currentTime, actualResponse.getCreatedDate());
+        assertEquals(SecretManagerService.SECRET_MANAGER_SERVICE_NAME, stringCaptor.getValue());
+        assertEquals(SecretManagerService.SECRETS_AUTHORIZATION_OPCODE, permissionCaptor.getValue().getOperation());
+        assertEquals(serviceName, permissionCaptor.getValue().getPrincipal());
+        assertEquals(SECRET_ID, permissionCaptor.getValue().getResource());
+        verify(mockAuthorizationHandler, atLeastOnce()).registerComponent(SecretManagerService.SECRET_MANAGER_SERVICE_NAME,
+                new HashSet<>(Arrays.asList(SecretManagerService.SECRETS_AUTHORIZATION_OPCODE)));
+    }
+
+    @Test
+    void GIVEN_secret_service_WHEN_v1_get_called_and_errors_THEN_correct_response_returned() throws Exception {
+        startKernelWithConfig("config.yaml", State.RUNNING);
+        final String secretValue = "secretValue";
+        final String serviceName = "mockService";
+        final Date currentTime = Date.from(Instant.now());
+        com.aws.greengrass.secretmanager.model.v1.GetSecretValueResult expectedResponse =
+                com.aws.greengrass.secretmanager.model.v1.GetSecretValueResult.builder()
+                        .secretString(secretValue)
+                        .arn(SECRET_ID)
+                        .name(SECRET_NAME)
+                        .versionId(VERSION_ID)
+                        .versionStages(Arrays.asList(new String[]{CURRENT_LABEL, VERSION_LABEL}))
+                        .createdDate(currentTime)
+                        .build();
+
+
+        when(mockSecretManager.getSecret(any(com.aws.greengrass.secretmanager.model.v1.GetSecretValueRequest.class)))
+                .thenThrow(new GetSecretException(400, "getSecret Error"));
+        when(mockAuthorizationHandler.isAuthorized(any(), any())).thenReturn(true);
+
+        com.aws.greengrass.secretmanager.model.v1.GetSecretValueRequest request =
+                com.aws.greengrass.secretmanager.model.v1.GetSecretValueRequest.builder()
+                        .secretId(SECRET_ID)
+                        .versionId(VERSION_ID)
+                        .build();
+        byte[] byteRequest = CBOR_MAPPER.writeValueAsBytes(request);
+        byte[] response = kernel.getContext().get(SecretManagerService.class).getSecret(serviceName, byteRequest);
+
+        com.aws.greengrass.secretmanager.model.v1.GetSecretValueError parsedResponse =
+                CBOR_MAPPER.readValue(response,
+                        com.aws.greengrass.secretmanager.model.v1.GetSecretValueError.class);
+
+        assertEquals(400, parsedResponse.getStatus());
+        assertEquals("getSecret Error", parsedResponse.getMessage());
+
+        // Now passing bogus request
+        response = kernel.getContext().get(SecretManagerService.class).getSecret(serviceName, "Hello".getBytes());
+        parsedResponse = CBOR_MAPPER.readValue(response,
+                com.aws.greengrass.secretmanager.model.v1.GetSecretValueError.class);
+
+        assertEquals(400, parsedResponse.getStatus());
+        assertEquals("Unable to parse request", parsedResponse.getMessage());
+
+        // now let the auth fail
+        when(mockAuthorizationHandler.isAuthorized(any(), any())).
+                thenThrow(new AuthorizationException("Auth error"));
+        response = kernel.getContext().get(SecretManagerService.class).getSecret(serviceName, byteRequest);
+        parsedResponse = CBOR_MAPPER.readValue(response,
+                com.aws.greengrass.secretmanager.model.v1.GetSecretValueError.class);
+
+        assertEquals(403, parsedResponse.getStatus());
+        assertEquals("Auth error", parsedResponse.getMessage());
+
+        //Case for generic errors
+        reset(mockAuthorizationHandler);
+        when(mockAuthorizationHandler.isAuthorized(any(), any())).thenReturn(true);
+        when(mockSecretManager.getSecret(any(com.aws.greengrass.secretmanager.model.v1.GetSecretValueRequest.class)))
+                .thenThrow(new RuntimeException("Generic Error"));
+        response = kernel.getContext().get(SecretManagerService.class).getSecret(serviceName, byteRequest);
+        parsedResponse = CBOR_MAPPER.readValue(response,
+                com.aws.greengrass.secretmanager.model.v1.GetSecretValueError.class);
+
+        assertEquals(500, parsedResponse.getStatus());
+        assertEquals("Generic Error", parsedResponse.getMessage());
+    }
+
+    @Test
+    void GIVEN_secret_service_WHEN_v1_get_called_THEN_correct_errors_returned(ExtensionContext context)
+            throws Exception {
+        ignoreExceptionOfType(context, AuthorizationException.class);
+        startKernelWithConfig("config.yaml", State.RUNNING);
+        final String serviceName = "mockService";
+
+        when(mockAuthorizationHandler.isAuthorized(any(), any())).thenThrow(AuthorizationException.class);
+        com.aws.greengrass.secretmanager.model.v1.GetSecretValueRequest request =
+                com.aws.greengrass.secretmanager.model.v1.GetSecretValueRequest.builder()
+                        .secretId(SECRET_ID)
+                        .versionId(VERSION_ID)
+                        .build();
+        byte[] byteRequest = CBOR_MAPPER.writeValueAsBytes(request);
+        byte[] response = kernel.getContext().get(SecretManagerService.class).getSecret(serviceName, byteRequest);
+        com.aws.greengrass.secretmanager.model.v1.GetSecretValueError actualResponse =
+                CBOR_MAPPER.readValue(response,
+                        com.aws.greengrass.secretmanager.model.v1.GetSecretValueError.class);
+
+        assertEquals(403, actualResponse.getStatus());
+
+        // simulate get secret throwing exception internally
+        reset(mockAuthorizationHandler);
+        when(mockAuthorizationHandler.isAuthorized(any(), any())).thenReturn(true);
+        GetSecretException exception = new GetSecretException(400, "test");
+        when(mockSecretManager.getSecret(any(com.aws.greengrass.secretmanager.model.v1.GetSecretValueRequest.class)))
+                .thenThrow(exception);
+        response = kernel.getContext().get(SecretManagerService.class).getSecret(serviceName, byteRequest);
+        actualResponse = CBOR_MAPPER.readValue(response,
+                        com.aws.greengrass.secretmanager.model.v1.GetSecretValueError.class);
+        assertEquals(400, actualResponse.getStatus());
+        assertThat(actualResponse.getMessage(), containsString("test"));
+
+        // Now send in a bad request
+        byteRequest = CBOR_MAPPER.writeValueAsBytes("bad request");
+        response = kernel.getContext().get(SecretManagerService.class).getSecret(serviceName, byteRequest);
+        actualResponse = CBOR_MAPPER.readValue(response,
+                com.aws.greengrass.secretmanager.model.v1.GetSecretValueError.class);
+        assertEquals(400, actualResponse.getStatus());
+        assertThat(actualResponse.getMessage(), containsString("Unable to parse request"));
+    }
+
 
     @Test
     void GIVEN_secret_service_WHEN_request_unauthorized_THEN_correct_response_returned(ExtensionContext context) throws Exception {

--- a/src/test/java/com/aws/greengrass/secretmanager/SecretManagerTest.java
+++ b/src/test/java/com/aws/greengrass/secretmanager/SecretManagerTest.java
@@ -33,17 +33,22 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
 
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.security.PrivateKey;
 import java.security.PublicKey;
+import java.sql.Date;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -51,6 +56,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -307,6 +313,104 @@ class SecretManagerTest {
         assertEquals(2, getSecretValueResult.getVersionStages().size());
         assertEquals(LATEST_LABEL, getSecretValueResult.getVersionStages().get(0));
         assertEquals(SECRET_LABEL_2, getSecretValueResult.getVersionStages().get(1));
+    }
+
+    @Test
+    void GIVEN_secret_manager_WHEN_sync_from_cloud_THEN_v1_secret_api_works() throws Exception {
+        when(mockAWSSecretClient.getSecret(any())).thenReturn(getMockSecretA()).thenReturn(getMockSecretB());
+        List<AWSSecretResponse> storedSecrets = new ArrayList<>();
+        storedSecrets.add(getMockDaoSecretA());
+        storedSecrets.add(getMockDaoSecretB());
+        when(mockDao.getAll()).thenReturn(SecretDocument.builder().secrets(storedSecrets).build());
+        SecretManager sm = new SecretManager(mockAWSSecretClient, crypter, mockDao);
+        sm.syncFromCloud(getMockSecrets());
+
+        com.aws.greengrass.secretmanager.model.v1.GetSecretValueRequest request =
+                com.aws.greengrass.secretmanager.model.v1.GetSecretValueRequest
+                        .builder().secretId(SECRET_NAME_1).build();
+        com.aws.greengrass.secretmanager.model.v1.GetSecretValueResult getSecretValueResult = sm.getSecret(request);
+
+        assertEquals(SECRET_VALUE_1, getSecretValueResult.getSecretString());
+        assertEquals(ByteBuffer.wrap(SECRET_VALUE_BINARY_1), getSecretValueResult.getSecretBinary());
+        assertEquals(Date.from(SECRET_DATE_1), getSecretValueResult.getCreatedDate());
+        assertEquals(SECRET_NAME_1, getSecretValueResult.getName());
+        assertEquals(ARN_1, getSecretValueResult.getArn());
+        assertEquals(SECRET_VERSION_1, getSecretValueResult.getVersionId());
+        assertEquals(2, getSecretValueResult.getVersionStages().size());
+        assertThat(getSecretValueResult.getVersionStages(), hasItem(LATEST_LABEL));
+        assertThat(getSecretValueResult.getVersionStages(), hasItem(SECRET_LABEL_1));
+
+        request = com.aws.greengrass.secretmanager.model.v1.GetSecretValueRequest
+                .builder().secretId(SECRET_NAME_2).build();
+        getSecretValueResult = sm.getSecret(request);
+
+        assertEquals(SECRET_VALUE_2, getSecretValueResult.getSecretString());
+        assertEquals(ByteBuffer.wrap(SECRET_VALUE_BINARY_2), getSecretValueResult.getSecretBinary());
+        assertEquals(Date.from(SECRET_DATE_2), getSecretValueResult.getCreatedDate());
+        assertEquals(SECRET_NAME_2, getSecretValueResult.getName());
+        assertEquals(ARN_2, getSecretValueResult.getArn());
+        assertEquals(SECRET_VERSION_2, getSecretValueResult.getVersionId());
+        assertEquals(2, getSecretValueResult.getVersionStages().size());
+        assertThat(getSecretValueResult.getVersionStages(), hasItem(LATEST_LABEL));
+        assertThat(getSecretValueResult.getVersionStages(), hasItem(SECRET_LABEL_2));
+
+        // Make a request with a label
+        request = com.aws.greengrass.secretmanager.model.v1.GetSecretValueRequest
+                .builder().secretId(SECRET_NAME_1).versionStage(SECRET_LABEL_1).build();
+        getSecretValueResult = sm.getSecret(request);
+
+        assertEquals(SECRET_VALUE_1, getSecretValueResult.getSecretString());
+        assertEquals(ByteBuffer.wrap(SECRET_VALUE_BINARY_1), getSecretValueResult.getSecretBinary());
+        assertEquals(Date.from(SECRET_DATE_1), getSecretValueResult.getCreatedDate());
+        assertEquals(SECRET_NAME_1, getSecretValueResult.getName());
+        assertEquals(ARN_1, getSecretValueResult.getArn());
+        assertEquals(SECRET_VERSION_1, getSecretValueResult.getVersionId());
+        assertEquals(2, getSecretValueResult.getVersionStages().size());
+        assertThat(getSecretValueResult.getVersionStages(), hasItem(LATEST_LABEL));
+        assertThat(getSecretValueResult.getVersionStages(), hasItem(SECRET_LABEL_1));
+
+        request = com.aws.greengrass.secretmanager.model.v1.GetSecretValueRequest
+                .builder().secretId(SECRET_NAME_2).versionStage(SECRET_LABEL_2).build();
+        getSecretValueResult = sm.getSecret(request);
+
+        assertEquals(SECRET_VALUE_2, getSecretValueResult.getSecretString());
+        assertEquals(ByteBuffer.wrap(SECRET_VALUE_BINARY_2), getSecretValueResult.getSecretBinary());
+        assertEquals(Date.from(SECRET_DATE_2), getSecretValueResult.getCreatedDate());
+        assertEquals(SECRET_NAME_2, getSecretValueResult.getName());
+        assertEquals(ARN_2, getSecretValueResult.getArn());
+        assertEquals(SECRET_VERSION_2, getSecretValueResult.getVersionId());
+        assertEquals(2, getSecretValueResult.getVersionStages().size());
+        assertThat(getSecretValueResult.getVersionStages(), hasItem(LATEST_LABEL));
+        assertThat(getSecretValueResult.getVersionStages(), hasItem(SECRET_LABEL_2));
+
+        // Make a request with version id now
+        request = com.aws.greengrass.secretmanager.model.v1.GetSecretValueRequest
+                .builder().secretId(SECRET_NAME_1).versionId(SECRET_VERSION_1).build();
+        getSecretValueResult = sm.getSecret(request);
+
+        assertEquals(SECRET_VALUE_1, getSecretValueResult.getSecretString());
+        assertEquals(ByteBuffer.wrap(SECRET_VALUE_BINARY_1), getSecretValueResult.getSecretBinary());
+        assertEquals(ARN_1, getSecretValueResult.getArn());
+        assertEquals(SECRET_NAME_1, getSecretValueResult.getName());
+        assertEquals(Date.from(SECRET_DATE_1), getSecretValueResult.getCreatedDate());
+        assertEquals(SECRET_VERSION_1, getSecretValueResult.getVersionId());
+        assertEquals(2, getSecretValueResult.getVersionStages().size());
+        assertThat(getSecretValueResult.getVersionStages(), hasItem(LATEST_LABEL));
+        assertThat(getSecretValueResult.getVersionStages(), hasItem(SECRET_LABEL_1));
+
+        request = com.aws.greengrass.secretmanager.model.v1.GetSecretValueRequest
+                .builder().secretId(SECRET_NAME_2).versionId(SECRET_VERSION_2).build();
+        getSecretValueResult = sm.getSecret(request);
+
+        assertEquals(SECRET_VALUE_2, getSecretValueResult.getSecretString());
+        assertEquals(ByteBuffer.wrap(SECRET_VALUE_BINARY_2), getSecretValueResult.getSecretBinary());
+        assertEquals(Date.from(SECRET_DATE_2), getSecretValueResult.getCreatedDate());
+        assertEquals(SECRET_NAME_2, getSecretValueResult.getName());
+        assertEquals(ARN_2, getSecretValueResult.getArn());
+        assertEquals(SECRET_VERSION_2, getSecretValueResult.getVersionId());
+        assertEquals(2, getSecretValueResult.getVersionStages().size());
+        assertThat(getSecretValueResult.getVersionStages(), hasItem(LATEST_LABEL));
+        assertThat(getSecretValueResult.getVersionStages(), hasItem(SECRET_LABEL_2));
     }
 
     @Test


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add new methods for lambdas to be able to get secrets 

**Why is this change necessary:**
For backward compatibility with v1. Lambdas can use v1 SDK for fetching secrets, and this change lets lambda manager use the new method to fetch secrets from secret manager.

**How was this change tested:**
UT

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
