### PR TITLE
Add secret name support for API calls from lambda and IPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Secret Manager is a Greengrass component that manages sensitive data stored with
  
  1. How are secrets stored on greengrass device?
  
-    Secrets are stored encrypted using a private key provided by the user or by default using the IoT thing 
+    Secrets are stored encrypted using the IoT thing 
     key associated with kernel.
     
  2. When are secrets synchronized from the cloud?


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Validate secret id in the request for IPC and Lambda API to support secret name

**Why is this change necessary:**
Request can take in secret name but auth policy only handles secret arn, so need to add the mapping

**How was this change tested:**
UT

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
