### PR TITLE
Modify getSecret return type

### DIFF
--- a/src/main/java/com/aws/greengrass/secretmanager/SecretManagerService.java
+++ b/src/main/java/com/aws/greengrass/secretmanager/SecretManagerService.java
@@ -37,7 +37,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.cbor.databind.CBORMapper;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.EnumMap;
 import java.util.HashSet;
@@ -168,8 +167,7 @@ public class SecretManagerService extends PluginService {
                     getSecretValueRequest.getSecretId());
             logger.atInfo().event("secret-access").kv("Principal", serviceName)
                     .kv("secret", getSecretValueRequest.getSecretId()).log("requested secret");
-            return GetSecretResponse.builder()
-                    .secret(CBOR_MAPPER.writeValueAsBytes(secretManager.getSecret(getSecretValueRequest))).build();
+            return GetSecretResponse.builder().secret(secretManager.getSecret(getSecretValueRequest)).build();
         } catch (GetSecretException t) {
             status = t.getStatus();
             message = t.getMessage();
@@ -183,13 +181,8 @@ public class SecretManagerService extends PluginService {
             status = 500;
             message = t.getMessage();
         }
-        try {
-            return GetSecretResponse.builder().error(CBOR_MAPPER
-                    .writeValueAsBytes(GetSecretValueError.builder().status(status).message(message).build())).build();
-        } catch (IOException e) {
-            logger.atError("secret-error").setCause(e).log("Failed to send error response");
-        }
-        return GetSecretResponse.builder().error("Internal Error".getBytes(StandardCharsets.UTF_8)).build();
+        return GetSecretResponse.builder().error(GetSecretValueError.builder().status(status).message(message)
+                .build()).build();
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/secretmanager/model/GetSecretResponse.java
+++ b/src/main/java/com/aws/greengrass/secretmanager/model/GetSecretResponse.java
@@ -5,7 +5,8 @@
 
 package com.aws.greengrass.secretmanager.model;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
+import com.aws.greengrass.secretmanager.model.v1.GetSecretValueError;
+import com.aws.greengrass.secretmanager.model.v1.GetSecretValueResult;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -16,6 +17,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Data
 public class GetSecretResponse {
-    byte[] secret;
-    byte[] error;
+    GetSecretValueResult secret;
+    GetSecretValueError error;
 }

--- a/src/test/java/com/aws/greengrass/secretmanager/SecretManagerServiceTest.java
+++ b/src/test/java/com/aws/greengrass/secretmanager/SecretManagerServiceTest.java
@@ -222,11 +222,8 @@ public class SecretManagerServiceTest {
         byte[] byteRequest = CBOR_MAPPER.writeValueAsBytes(request);
         GetSecretResponse getSecretResponse =
                 kernel.getContext().get(SecretManagerService.class).getSecret(serviceName, byteRequest);
-        byte[] response = getSecretResponse.getSecret();
 
-        com.aws.greengrass.secretmanager.model.v1.GetSecretValueResult actualResponse =
-                CBOR_MAPPER.readValue(response,
-                        com.aws.greengrass.secretmanager.model.v1.GetSecretValueResult.class);
+        com.aws.greengrass.secretmanager.model.v1.GetSecretValueResult actualResponse = getSecretResponse.getSecret();
 
         assertNull(getSecretResponse.getError());
         assertEquals(SECRET_ID, actualResponse.getArn());
@@ -251,10 +248,8 @@ public class SecretManagerServiceTest {
         byte[] newByteRequest = CBOR_MAPPER.writeValueAsBytes(newRequest);
         getSecretResponse =
                 kernel.getContext().get(SecretManagerService.class).getSecret(serviceName, newByteRequest);
-        byte[] newResponse = getSecretResponse.getSecret();
 
-        com.aws.greengrass.secretmanager.model.v1.GetSecretValueResult newActualResponse = CBOR_MAPPER
-                .readValue(newResponse, com.aws.greengrass.secretmanager.model.v1.GetSecretValueResult.class);
+        com.aws.greengrass.secretmanager.model.v1.GetSecretValueResult newActualResponse = getSecretResponse.getSecret();
         assertEquals(actualResponse, newActualResponse);
     }
 
@@ -275,22 +270,17 @@ public class SecretManagerServiceTest {
         byte[] byteRequest = CBOR_MAPPER.writeValueAsBytes(request);
         GetSecretResponse getSecretResponse =
                 kernel.getContext().get(SecretManagerService.class).getSecret(serviceName, byteRequest);
-        byte[] response = getSecretResponse.getError();
         assertNull(getSecretResponse.getSecret());
 
-        com.aws.greengrass.secretmanager.model.v1.GetSecretValueError parsedResponse =
-                CBOR_MAPPER.readValue(response,
-                        com.aws.greengrass.secretmanager.model.v1.GetSecretValueError.class);
+        com.aws.greengrass.secretmanager.model.v1.GetSecretValueError parsedResponse = getSecretResponse.getError();
 
         assertEquals(400, parsedResponse.getStatus());
         assertEquals("getSecret Error", parsedResponse.getMessage());
 
         // Now passing bogus request
         getSecretResponse = kernel.getContext().get(SecretManagerService.class).getSecret(serviceName, "Hello".getBytes());
-        response = getSecretResponse.getError();
         assertNull(getSecretResponse.getSecret());
-        parsedResponse = CBOR_MAPPER.readValue(response,
-                com.aws.greengrass.secretmanager.model.v1.GetSecretValueError.class);
+        parsedResponse = getSecretResponse.getError();
 
         assertEquals(400, parsedResponse.getStatus());
         assertEquals("Unable to parse request", parsedResponse.getMessage());
@@ -299,10 +289,8 @@ public class SecretManagerServiceTest {
         when(mockAuthorizationHandler.isAuthorized(any(), any())).
                 thenThrow(new AuthorizationException("Auth error"));
         getSecretResponse = kernel.getContext().get(SecretManagerService.class).getSecret(serviceName, byteRequest);
-        response = getSecretResponse.getError();
         assertNull(getSecretResponse.getSecret());
-        parsedResponse = CBOR_MAPPER.readValue(response,
-                com.aws.greengrass.secretmanager.model.v1.GetSecretValueError.class);
+        parsedResponse = getSecretResponse.getError();
 
         assertEquals(403, parsedResponse.getStatus());
         assertEquals("Auth error", parsedResponse.getMessage());
@@ -313,10 +301,8 @@ public class SecretManagerServiceTest {
         when(mockSecretManager.getSecret(any(com.aws.greengrass.secretmanager.model.v1.GetSecretValueRequest.class)))
                 .thenThrow(new RuntimeException("Generic Error"));
         getSecretResponse = kernel.getContext().get(SecretManagerService.class).getSecret(serviceName, byteRequest);
-        response = getSecretResponse.getError();
         assertNull(getSecretResponse.getSecret());
-        parsedResponse = CBOR_MAPPER.readValue(response,
-                com.aws.greengrass.secretmanager.model.v1.GetSecretValueError.class);
+        parsedResponse = getSecretResponse.getError();
 
         assertEquals(500, parsedResponse.getStatus());
         assertEquals("Generic Error", parsedResponse.getMessage());
@@ -324,10 +310,8 @@ public class SecretManagerServiceTest {
         // Now invalid secretId
         when(mockSecretManager.validateSecretId(SECRET_ID)).thenThrow(new GetSecretException(400, "getSecret Error"));
         getSecretResponse = kernel.getContext().get(SecretManagerService.class).getSecret(serviceName, byteRequest);
-        response = getSecretResponse.getError();
         assertNull(getSecretResponse.getSecret());
-        parsedResponse =
-                CBOR_MAPPER.readValue(response, com.aws.greengrass.secretmanager.model.v1.GetSecretValueError.class);
+        parsedResponse = getSecretResponse.getError();
 
         assertEquals(400, parsedResponse.getStatus());
         assertEquals("getSecret Error", parsedResponse.getMessage());
@@ -348,11 +332,8 @@ public class SecretManagerServiceTest {
                         .build();
         byte[] byteRequest = CBOR_MAPPER.writeValueAsBytes(request);
         GetSecretResponse getSecretResponse = kernel.getContext().get(SecretManagerService.class).getSecret(serviceName, byteRequest);
-        byte[] response = getSecretResponse.getError();
         assertNull(getSecretResponse.getSecret());
-        com.aws.greengrass.secretmanager.model.v1.GetSecretValueError actualResponse =
-                CBOR_MAPPER.readValue(response,
-                        com.aws.greengrass.secretmanager.model.v1.GetSecretValueError.class);
+        com.aws.greengrass.secretmanager.model.v1.GetSecretValueError actualResponse = getSecretResponse.getError();
 
         assertEquals(403, actualResponse.getStatus());
 
@@ -363,20 +344,16 @@ public class SecretManagerServiceTest {
         when(mockSecretManager.getSecret(any(com.aws.greengrass.secretmanager.model.v1.GetSecretValueRequest.class)))
                 .thenThrow(exception);
         getSecretResponse = kernel.getContext().get(SecretManagerService.class).getSecret(serviceName, byteRequest);
-        response = getSecretResponse.getError();
         assertNull(getSecretResponse.getSecret());
-        actualResponse = CBOR_MAPPER.readValue(response,
-                        com.aws.greengrass.secretmanager.model.v1.GetSecretValueError.class);
+        actualResponse = getSecretResponse.getError();
         assertEquals(400, actualResponse.getStatus());
         assertThat(actualResponse.getMessage(), containsString("test"));
 
         // Now send in a bad request
         byteRequest = CBOR_MAPPER.writeValueAsBytes("bad request");
         getSecretResponse = kernel.getContext().get(SecretManagerService.class).getSecret(serviceName, byteRequest);
-        response = getSecretResponse.getError();
         assertNull(getSecretResponse.getSecret());
-        actualResponse = CBOR_MAPPER.readValue(response,
-                com.aws.greengrass.secretmanager.model.v1.GetSecretValueError.class);
+        actualResponse = getSecretResponse.getError();
         assertEquals(400, actualResponse.getStatus());
         assertThat(actualResponse.getMessage(), containsString("Unable to parse request"));
     }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Return GetSecretRespnse for getSecret() that either returns the secret or error bytes

**Why is this change necessary:**
For lambda manger, to differentiate two cases when reading payload
https://github.com/aws/aws-greengrass-lambda-manager/pull/48

**How was this change tested:**
UT

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
