### PR TITLE
Add proxy config for secret client

### DIFF
--- a/src/main/java/com/aws/greengrass/secretmanager/AWSSecretClient.java
+++ b/src/main/java/com/aws/greengrass/secretmanager/AWSSecretClient.java
@@ -6,15 +6,13 @@
 package com.aws.greengrass.secretmanager;
 
 import com.aws.greengrass.deployment.DeviceConfiguration;
-import com.aws.greengrass.deployment.exceptions.AWSIotException;
-import com.aws.greengrass.iot.model.IotCloudResponse;
 import com.aws.greengrass.secretmanager.exception.SecretManagerException;
 import com.aws.greengrass.tes.LazyCredentialProvider;
 import com.aws.greengrass.util.BaseRetryableAccessor;
 import com.aws.greengrass.util.Coerce;
 import com.aws.greengrass.util.CrashableSupplier;
+import com.aws.greengrass.util.ProxyUtils;
 import com.aws.greengrass.util.Utils;
-import software.amazon.awssdk.crt.http.HttpClientConnection;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.secretsmanager.model.DecryptionFailureException;
@@ -26,7 +24,6 @@ import software.amazon.awssdk.services.secretsmanager.model.InvalidRequestExcept
 import software.amazon.awssdk.services.secretsmanager.model.ResourceNotFoundException;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import javax.inject.Inject;
@@ -45,8 +42,8 @@ public class AWSSecretClient {
     @Inject
     public AWSSecretClient(LazyCredentialProvider credentialProvider, DeviceConfiguration deviceConfiguration) {
         Region region = Region.of(Coerce.toString(deviceConfiguration.getAWSRegion()));
-        this.secretsManagerClient = SecretsManagerClient.builder().credentialsProvider(credentialProvider)
-                .region(region).build();
+        this.secretsManagerClient = SecretsManagerClient.builder().httpClient(ProxyUtils.getSdkHttpClient())
+                .credentialsProvider(credentialProvider).region(region).build();
     }
 
     // Constructor used for testing.

--- a/src/main/java/com/aws/greengrass/secretmanager/SecretManager.java
+++ b/src/main/java/com/aws/greengrass/secretmanager/SecretManager.java
@@ -52,7 +52,7 @@ public class SecretManager {
     public static final String VALID_SECRET_ARN_PATTERN =
             "arn:aws:secretsmanager:[a-z0-9\\-]+:[0-9]{12}:secret:([a-zA-Z0-9\\\\]+/)*"
                     + "[a-zA-Z0-9/_+=,.@\\-]+-[a-zA-Z0-9]+";
-    private final String secretNotFoundErr = "Secret not found ";
+    private static final String secretNotFoundErr = "Secret not found ";
     private final Logger logger = LogManager.getLogger(SecretManager.class);
     // Cache which holds aws secrets result
     private ConcurrentHashMap<String, GetSecretValueResponse> cache = new ConcurrentHashMap<>();

--- a/src/main/java/com/aws/greengrass/secretmanager/crypto/RSAMasterKey.java
+++ b/src/main/java/com/aws/greengrass/secretmanager/crypto/RSAMasterKey.java
@@ -13,7 +13,6 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
-import java.util.UUID;
 
 public class RSAMasterKey implements MasterKey {
     // Metadata used by JCEMasterKey, so that another instance of JCEMasterKey cannot be used


### PR DESCRIPTION
When kernel is configured to use proxy, then secrets client should also switch to using the proxy.

**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**
This is required so that customers can use secrets manager when kernel is configured to use a proxy.

**How was this change tested:**
ran UAT with proxy configuration on kernel and validated that proxy was hit and test succeeded.
```
bb cucumber --args="-n Security-1-T2"

1 Scenarios (1 passed)
7 Steps (7 passed)
1m9.512s


21 Oct 2020 12:37:52,672 [INFO ] {} (Thread-1) com.aws.iot.evergreen.module.ResourceCleanupModule$CleanupRunnable:35: Cleaning up orphaned resources

BUILD SUCCESSFUL in 1m 47s
```
```
2020-10-21 19:35:13,640 - pid:7 [I] access_log:338 - 172.17.0.1:59486 - CONNECT secretsmanager.us-east-1.amazonaws.com:443 - 5844 bytes - 10590.80 ms
```
**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
