### PR TITLE
Set either secret string or binary for v1 IPC

### DIFF
--- a/src/main/java/com/aws/greengrass/secretmanager/SecretManager.java
+++ b/src/main/java/com/aws/greengrass/secretmanager/SecretManager.java
@@ -360,16 +360,24 @@ public class SecretManager {
 
     private com.aws.greengrass.secretmanager.model.v1.GetSecretValueResult
         translateModeltov1(GetSecretValueResponse response) {
-        byte[] secretBinary = null;
         if (response.secretBinary() != null) {
-            secretBinary = response.secretBinary().asByteArray();
+            return com.aws.greengrass.secretmanager.model.v1.GetSecretValueResult
+                    .builder()
+                    .arn(response.arn())
+                    .name(response.name())
+                    .secretString(null)
+                    .secretBinary(ByteBuffer.wrap(response.secretBinary().asByteArray()))
+                    .versionId(response.versionId())
+                    .versionStages(response.versionStages())
+                    .createdDate(Date.from(response.createdDate()))
+                    .build();
         }
         return com.aws.greengrass.secretmanager.model.v1.GetSecretValueResult
                 .builder()
                 .arn(response.arn())
                 .name(response.name())
                 .secretString(response.secretString())
-                .secretBinary(ByteBuffer.wrap(secretBinary))
+                .secretBinary(null)
                 .versionId(response.versionId())
                 .versionStages(response.versionStages())
                 .createdDate(Date.from(response.createdDate()))

--- a/src/main/java/com/aws/greengrass/secretmanager/model/v1/GetSecretValueError.java
+++ b/src/main/java/com/aws/greengrass/secretmanager/model/v1/GetSecretValueError.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class GetSecretValueError extends Exception {
+public class GetSecretValueError {
     /**
      * Status code for the error response.
      */

--- a/src/test/java/com/aws/greengrass/secretmanager/SecretManagerServiceTest.java
+++ b/src/test/java/com/aws/greengrass/secretmanager/SecretManagerServiceTest.java
@@ -252,7 +252,9 @@ public class SecretManagerServiceTest {
     }
 
     @Test
-    void GIVEN_secret_service_WHEN_v1_get_called_and_errors_THEN_correct_response_returned() throws Exception {
+    void GIVEN_secret_service_WHEN_v1_get_called_and_errors_THEN_correct_response_returned(ExtensionContext context)
+            throws Exception {
+        ignoreExceptionOfType(context, RuntimeException.class);
         startKernelWithConfig("config.yaml", State.RUNNING);
         final String serviceName = "mockService";
 

--- a/src/test/java/com/aws/greengrass/secretmanager/SecretManagerTest.java
+++ b/src/test/java/com/aws/greengrass/secretmanager/SecretManagerTest.java
@@ -316,10 +316,11 @@ class SecretManagerTest {
 
     @Test
     void GIVEN_secret_manager_WHEN_sync_from_cloud_THEN_v1_secret_api_works() throws Exception {
-        when(mockAWSSecretClient.getSecret(any())).thenReturn(getMockSecretA()).thenReturn(getMockSecretB());
+        when(mockAWSSecretClient.getSecret(any())).thenReturn(getMockSecretAWithSecretString())
+                .thenReturn(getMockSecretBWithSecretBinary());
         List<AWSSecretResponse> storedSecrets = new ArrayList<>();
-        storedSecrets.add(getMockDaoSecretA());
-        storedSecrets.add(getMockDaoSecretB());
+        storedSecrets.add(getMockDaoSecretAWithSecretString());
+        storedSecrets.add(getMockDaoSecretBWithSecretBinary());
         when(mockDao.getAll()).thenReturn(SecretDocument.builder().secrets(storedSecrets).build());
         SecretManager sm = new SecretManager(mockAWSSecretClient, crypter, mockDao);
         sm.syncFromCloud(getMockSecrets());
@@ -330,7 +331,6 @@ class SecretManagerTest {
         com.aws.greengrass.secretmanager.model.v1.GetSecretValueResult getSecretValueResult = sm.getSecret(request);
 
         assertEquals(SECRET_VALUE_1, getSecretValueResult.getSecretString());
-        assertEquals(ByteBuffer.wrap(SECRET_VALUE_BINARY_1), getSecretValueResult.getSecretBinary());
         assertEquals(Date.from(SECRET_DATE_1), getSecretValueResult.getCreatedDate());
         assertEquals(SECRET_NAME_1, getSecretValueResult.getName());
         assertEquals(ARN_1, getSecretValueResult.getArn());
@@ -343,7 +343,6 @@ class SecretManagerTest {
                 .builder().secretId(SECRET_NAME_2).build();
         getSecretValueResult = sm.getSecret(request);
 
-        assertEquals(SECRET_VALUE_2, getSecretValueResult.getSecretString());
         assertEquals(ByteBuffer.wrap(SECRET_VALUE_BINARY_2), getSecretValueResult.getSecretBinary());
         assertEquals(Date.from(SECRET_DATE_2), getSecretValueResult.getCreatedDate());
         assertEquals(SECRET_NAME_2, getSecretValueResult.getName());
@@ -359,7 +358,6 @@ class SecretManagerTest {
         getSecretValueResult = sm.getSecret(request);
 
         assertEquals(SECRET_VALUE_1, getSecretValueResult.getSecretString());
-        assertEquals(ByteBuffer.wrap(SECRET_VALUE_BINARY_1), getSecretValueResult.getSecretBinary());
         assertEquals(Date.from(SECRET_DATE_1), getSecretValueResult.getCreatedDate());
         assertEquals(SECRET_NAME_1, getSecretValueResult.getName());
         assertEquals(ARN_1, getSecretValueResult.getArn());
@@ -372,7 +370,6 @@ class SecretManagerTest {
                 .builder().secretId(SECRET_NAME_2).versionStage(SECRET_LABEL_2).build();
         getSecretValueResult = sm.getSecret(request);
 
-        assertEquals(SECRET_VALUE_2, getSecretValueResult.getSecretString());
         assertEquals(ByteBuffer.wrap(SECRET_VALUE_BINARY_2), getSecretValueResult.getSecretBinary());
         assertEquals(Date.from(SECRET_DATE_2), getSecretValueResult.getCreatedDate());
         assertEquals(SECRET_NAME_2, getSecretValueResult.getName());
@@ -388,7 +385,6 @@ class SecretManagerTest {
         getSecretValueResult = sm.getSecret(request);
 
         assertEquals(SECRET_VALUE_1, getSecretValueResult.getSecretString());
-        assertEquals(ByteBuffer.wrap(SECRET_VALUE_BINARY_1), getSecretValueResult.getSecretBinary());
         assertEquals(ARN_1, getSecretValueResult.getArn());
         assertEquals(SECRET_NAME_1, getSecretValueResult.getName());
         assertEquals(Date.from(SECRET_DATE_1), getSecretValueResult.getCreatedDate());
@@ -401,7 +397,6 @@ class SecretManagerTest {
                 .builder().secretId(SECRET_NAME_2).versionId(SECRET_VERSION_2).build();
         getSecretValueResult = sm.getSecret(request);
 
-        assertEquals(SECRET_VALUE_2, getSecretValueResult.getSecretString());
         assertEquals(ByteBuffer.wrap(SECRET_VALUE_BINARY_2), getSecretValueResult.getSecretBinary());
         assertEquals(Date.from(SECRET_DATE_2), getSecretValueResult.getCreatedDate());
         assertEquals(SECRET_NAME_2, getSecretValueResult.getName());


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Fixes for lambda secret integration
* Fix NPE for binary secrets for v1 IPC
* GetSecretValueError should not extend Exception, as it adds exception details to serialized output

**Why is this change necessary:**
For secrets to be accessible within lambdas

**How was this change tested:**
UT
a new UAT which is yet to be posted for review.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
