### PR TITLE
Stop publishing as public component

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -94,7 +94,7 @@ jobs:
           artifactDirectoryPath: target/artifacts
           endpoint: https://evergreen-gamma.us-east-1.amazonaws.com
           autoBumpVersion: true
-          publishAsPublic: true
+          publishAsPublic: false
           additionalReplacements: '{"stage": "gamma"}'
       - uses: ./.github/actions/aws-greengrass-component-upload-action
         name: Upload to GCS Prod
@@ -105,5 +105,5 @@ jobs:
           artifactDirectoryPath: target/artifacts
           endpoint: https://evergreen.us-east-1.amazonaws.com
           autoBumpVersion: true
-          publishAsPublic: true
+          publishAsPublic: false
           additionalReplacements: '{"stage": "prod"}'


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Publish to prod would be done via CI/CD

**Why is this change necessary:**
To avoid publishing artifacts without CI/CD with every commit

**How was this change tested:**
```mvn package``` 

**Any additional information or context required to review the change:**
Part of the process to move our component publishing to CI/CD before release.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
