### PR TITLE
fix: move cloud sync from constructor to startup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -295,7 +295,7 @@
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>nucleus</artifactId>
-            <version>2.1.0-SNAPSHOT</version>
+            <version>2.3.0-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -254,7 +254,7 @@
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>nucleus</artifactId>
-            <version>2.1.0-SNAPSHOT</version>
+            <version>2.3.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -295,7 +295,7 @@
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>nucleus</artifactId>
-            <version>2.3.0-SNAPSHOT</version>
+            <version>2.1.0-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/com/aws/greengrass/secretmanager/SecretManagerService.java
+++ b/src/main/java/com/aws/greengrass/secretmanager/SecretManagerService.java
@@ -69,9 +69,6 @@ public class SecretManagerService extends PluginService {
         super(topics);
         this.secretManager = secretManager;
         this.authorizationHandler = authorizationHandler;
-        // GG_NEEDS_REVIEW: TODO: Subscribe on thing key updates
-        topics.lookup(CONFIGURATION_CONFIG_KEY, SECRETS_TOPIC)
-                .subscribe(this::serviceChanged);
     }
 
     private void serviceChanged(WhatHappened whatHappened, Topic secretParam) {
@@ -117,6 +114,10 @@ public class SecretManagerService extends PluginService {
 
     @Override
     public void startup() {
+        // subscribe will invoke serviceChanged right away to sync from cloud
+        // GG_NEEDS_REVIEW: TODO: Subscribe on thing key updates
+        this.config.lookup(CONFIGURATION_CONFIG_KEY, SECRETS_TOPIC).subscribe(this::serviceChanged);
+
         // GG_NEEDS_REVIEW: TODO: Modify secret service to only provide interface to deal with downloaded
         // secrets during download phase.
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Move `serviceChanged` subscription from constructor to startup step.

**Why is this change necessary:**
`serviceChanged` attempts to `syncFromCloud` which can fail with the following exception if the TES permission is not setup correctly.

```
com.aws.greengrass.secretmanager.SecretManagerService: Unable to download secrets from cloud. {service=aws.greengrass.SecretManager, serviceName=aws.greengrass.SecretManager, currentState=NEW}
com.aws.greengrass.secretmanager.exception.SecretManagerException: software.amazon.awssdk.services.secretsmanager.model.SecretsManagerException: User: arn:aws:sts::x:assumed-role/GreengrassV2TokenExchangeRole/x is not authorized to perform: secretsmanager:GetSecretValue on resource: arn:aws:secretsmanager:us-west-2:x:secret:test/secret-x (Service: SecretsManager, Status Code: 400, Request ID: x, Extended Request ID: null)
	at com.aws.greengrass.secretmanager.SecretManager.syncFromCloud(SecretManager.java:142)
	at com.aws.greengrass.secretmanager.SecretManagerService.serviceChanged(SecretManagerService.java:88)
	at com.aws.greengrass.config.Topic.subscribe(Topic.java:50)
	at com.aws.greengrass.secretmanager.SecretManagerService.<init>(SecretManagerService.java:74)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at com.aws.greengrass.dependency.Context$Value.constructObjectWithInjection(Context.java:475)
	at com.aws.greengrass.dependency.Context$Value.get(Context.java:424)
	at com.aws.greengrass.dependency.Context.newInstance(Context.java:118)
	at com.aws.greengrass.lifecyclemanager.Kernel.locateGreengrassService(Kernel.java:465)
	at com.aws.greengrass.lifecyclemanager.Kernel.lambda$locateIgnoreError$3(Kernel.java:378)
	at com.aws.greengrass.dependency.Context$Value.computeObjectIfEmpty(Context.java:550)
	at com.aws.greengrass.lifecyclemanager.Kernel.locateIgnoreError(Kernel.java:376)
	at com.aws.greengrass.lifecyclemanager.GreengrassService.getDependencyTypeMap(GreengrassService.java:552)
	at com.aws.greengrass.lifecyclemanager.GreengrassService.setupDependencies(GreengrassService.java:591)
	at com.aws.greengrass.lifecyclemanager.GreengrassService.lambda$initDependenciesTopic$0(GreengrassService.java:168)
	at com.aws.greengrass.config.Topic.fire(Topic.java:247)
	at com.aws.greengrass.config.Topic.lambda$withNewerValue$0(Topic.java:236)
	at com.aws.greengrass.dependency.Context$1.run(Context.java:67)
```

In the constructor, `subscribe` will invoke `serviceChanged` right away because it's a new subscription. If it fails, it reports `serviceErrored` from the constructor.

At [Context.java L475](https://github.com/aws-greengrass/aws-greengrass-nucleus/blob/main/src/main/java/com/aws/greengrass/dependency/Context.java#L475), the constructor is invoked before injection actions. Therefore, later at [Context.java L384](https://github.com/aws-greengrass/aws-greengrass-nucleus/blob/main/src/main/java/com/aws/greengrass/dependency/Context.java#L384), the service appears as errored, so `postInject` is skipped. Because `GreengrassService.postInject` kicks off the lifecycle, the SecretManagerService lifecycle never started, so it's stuck at NEW state without any transition or timeout. Meanwhile, the deployment workflow is stuck inside `while(true)` in `DeploymentConfigMerger#waitForServicesToStart` because it assumes there will be a timeout.


**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
