### PR TITLE
fix: read and write secrets to the runtime config

### DIFF
--- a/src/main/java/com/aws/greengrass/secretmanager/FileSecretDao.java
+++ b/src/main/java/com/aws/greengrass/secretmanager/FileSecretDao.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import javax.inject.Inject;
 
+import static com.aws.greengrass.lifecyclemanager.GreengrassService.RUNTIME_STORE_NAMESPACE_TOPIC;
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICES_NAMESPACE_TOPIC;
 
 /**
@@ -50,7 +51,8 @@ public class FileSecretDao implements SecretDao<SecretDocument, AWSSecretRespons
      */
     public synchronized SecretDocument getAll() throws SecretManagerException {
         Topic secretResponseTopic = kernelClient.getConfig().lookup(SERVICES_NAMESPACE_TOPIC,
-                    SecretManagerService.SECRET_MANAGER_SERVICE_NAME, SECRET_RESPONSE_TOPIC);
+                    SecretManagerService.SECRET_MANAGER_SERVICE_NAME, RUNTIME_STORE_NAMESPACE_TOPIC,
+                SECRET_RESPONSE_TOPIC);
         if (secretResponseTopic.getOnce() == null) {
             throw new NoSecretFoundException("No secrets found in file");
         }
@@ -92,7 +94,8 @@ public class FileSecretDao implements SecretDao<SecretDocument, AWSSecretRespons
      */
     public synchronized void saveAll(SecretDocument doc) throws SecretManagerException {
         Topic secretTopic = kernelClient.getConfig().lookup(SERVICES_NAMESPACE_TOPIC,
-                SecretManagerService.SECRET_MANAGER_SERVICE_NAME, SECRET_RESPONSE_TOPIC);
+                SecretManagerService.SECRET_MANAGER_SERVICE_NAME, RUNTIME_STORE_NAMESPACE_TOPIC,
+                SECRET_RESPONSE_TOPIC);
         try {
             secretTopic.withValue(OBJECT_MAPPER.writeValueAsString(doc));
         } catch (IOException e) {

--- a/src/test/java/com/aws/greengrass/secretmanager/FileSecretDaoTest.java
+++ b/src/test/java/com/aws/greengrass/secretmanager/FileSecretDaoTest.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
+import static com.aws.greengrass.lifecyclemanager.GreengrassService.RUNTIME_STORE_NAMESPACE_TOPIC;
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.SERVICES_NAMESPACE_TOPIC;
 import static com.aws.greengrass.secretmanager.FileSecretDao.SECRET_RESPONSE_TOPIC;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -105,7 +106,8 @@ class FileSecretDaoTest {
         FileSecretDao dao = new FileSecretDao(mockKernelClient);
         Topic mockTopic = mock(Topic.class);
         when(mockConfiguration.lookup(SERVICES_NAMESPACE_TOPIC,
-                SecretManagerService.SECRET_MANAGER_SERVICE_NAME, SECRET_RESPONSE_TOPIC)).thenReturn(mockTopic);
+                SecretManagerService.SECRET_MANAGER_SERVICE_NAME, RUNTIME_STORE_NAMESPACE_TOPIC,
+                SECRET_RESPONSE_TOPIC)).thenReturn(mockTopic);
 
 
         List<AWSSecretResponse> response = getSecrets();
@@ -196,7 +198,8 @@ class FileSecretDaoTest {
         FileSecretDao dao = new FileSecretDao(mockKernelClient);
         Topic mockTopic = mock(Topic.class);
         when(mockConfiguration.lookup(SERVICES_NAMESPACE_TOPIC,
-                SecretManagerService.SECRET_MANAGER_SERVICE_NAME, SECRET_RESPONSE_TOPIC)).thenReturn(mockTopic);
+                SecretManagerService.SECRET_MANAGER_SERVICE_NAME, RUNTIME_STORE_NAMESPACE_TOPIC,
+                SECRET_RESPONSE_TOPIC)).thenReturn(mockTopic);
         when(mockTopic.getOnce()).thenReturn(null);
 
         assertThrows(NoSecretFoundException.class, () -> dao.getAll());
@@ -208,7 +211,7 @@ class FileSecretDaoTest {
         FileSecretDao dao = new FileSecretDao(mockKernelClient);
         Topic mockTopic = mock(Topic.class);
         when(mockConfiguration.lookup(SERVICES_NAMESPACE_TOPIC, SecretManagerService.SECRET_MANAGER_SERVICE_NAME,
-                SECRET_RESPONSE_TOPIC)).thenReturn(mockTopic);
+                RUNTIME_STORE_NAMESPACE_TOPIC, SECRET_RESPONSE_TOPIC)).thenReturn(mockTopic);
         // Make readValue() throw JsonProcessingException
         when(Coerce.toString(mockTopic)).thenReturn(mockTopic.getClass().getName());
         assertThrows(SecretManagerException.class, () -> dao.getAll());


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**
Local secrets written to the service topic are lost when the secret manger is deployed again.  This change will write the secrets to the runtime config which will stay irrespective of the deployment. 

**How was this change tested:**
Existing tests are updated to work with the change. Need to add a few more tests to cover the cases.. 

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
