### PR TITLE
fix: retry fetching secrets forever due to ioexception

### DIFF
--- a/src/main/java/com/aws/greengrass/secretmanager/SecretManager.java
+++ b/src/main/java/com/aws/greengrass/secretmanager/SecretManager.java
@@ -168,17 +168,17 @@ public class SecretManager {
                                     .log("Secret configuration is not changed. Loaded from local store");
                         } catch (SecretCryptoException ex) {
                             e.addSuppressed(ex);
-                            throw new SecretManagerException(
-                                    String.format("Could not download secret %s with label %s from cloud, you can "
-                                            + "attempt a re-fetch by redeploying secret manager", secretArn, label),
-                                    e);
+                            throw new SecretManagerException(String.format(
+                                    "Could not download secret %s with label %s from cloud, you can "
+                                            + "attempt a re-fetch by redeploying secret manager", secretArn, label), e);
                         }
                     } else {
-                        throw new SecretManagerException(
-                                String.format("Could not download secret %s with label %s from cloud, you can "
-                                        + "attempt a re-fetch by redeploying secret manager", secretArn, label),
-                                e);
+                        throw new SecretManagerException(String.format(
+                                "Could not download secret %s with label %s from cloud, you can "
+                                        + "attempt a re-fetch by redeploying secret manager", secretArn, label), e);
                     }
+                } catch (InterruptedException e) {
+                    throw e;
                 } catch (Exception e) {
                     throw new SecretManagerException(e);
                 }
@@ -190,7 +190,7 @@ public class SecretManager {
     }
 
     private AWSSecretResponse fetchAndEncryptAWSResponse(GetSecretValueRequest request)
-            throws SecretCryptoException, SecretManagerException, IOException {
+            throws SecretCryptoException, SecretManagerException, IOException, InterruptedException {
         GetSecretValueResponse result = secretClient.getSecret(request);
         // Save the secrets to local store for offline access
         String encodedSecretString = null;


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Retry secret downloads forever if they fail due to IOExceptions such as when the device is offline.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
