### PR TITLE
chore: bump nucleus, aws sdk and component versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <groupId>com.aws.greengrass</groupId>
     <artifactId>secretmanager</artifactId>
     <packaging>jar</packaging>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <repositories>
         <repository>
             <id>greengrass-common</id>
@@ -51,7 +51,7 @@
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>bom</artifactId>
-                <version>2.15.47</version>
+                <version>2.20.138</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -266,7 +266,7 @@
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>nucleus</artifactId>
-            <version>2.5.0-SNAPSHOT</version>
+            <version>2.13.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -307,7 +307,7 @@
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>nucleus</artifactId>
-            <version>2.5.0-SNAPSHOT</version>
+            <version>2.13.0-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- Bump minor version of secret manager component snapshot version.
- Bump nucleus version to include GetSecretValueRequest IPC model changes. 
- Bump aws sdk version to include fips support.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
