### PR TITLE
fix: allow partial arn regex

### DIFF
--- a/src/main/java/com/aws/greengrass/secretmanager/SecretManager.java
+++ b/src/main/java/com/aws/greengrass/secretmanager/SecretManager.java
@@ -58,7 +58,7 @@ public class SecretManager {
     private static final String LATEST_LABEL = "AWSCURRENT";
     public static final String VALID_SECRET_ARN_PATTERN =
             "arn:([^:]+):secretsmanager:[a-z0-9\\-]+:[0-9]{12}:secret:([a-zA-Z0-9\\\\]+/)*"
-                    + "[a-zA-Z0-9/_+=,.@\\-]+-[a-zA-Z0-9]+";
+                    + "[a-zA-Z0-9/_+=,.@\\-]+(-[a-zA-Z0-9]+)?";
     private static final String secretNotFoundErr = "Secret not found ";
     private final Logger logger = LogManager.getLogger(SecretManager.class);
     // Cache which holds aws secrets result

--- a/src/test/java/com/aws/greengrass/secretmanager/SecretManagerTest.java
+++ b/src/test/java/com/aws/greengrass/secretmanager/SecretManagerTest.java
@@ -95,6 +95,7 @@ class SecretManagerTest {
     private static final String ARN_1 = "arn:aws:secretsmanager:us-east-1:999936977227:secret:randomSecret-74lYJh";
     private static final String ARN_2 = "arn:aws:secretsmanager:us-east-1:111136977227:secret:shhhhh-32lYsd";
     private static final String ARN_3 = "arn:aws-us-gov:secretsmanager:us-east-1:111136977227:secret:shhhhh-32lYsd";
+    private static final String PARTIAL_ARN = "arn:aws:secretsmanager:us-east-1:999936977227:secret:randomSecret";
 
     private String ENCRYPTED_SECRET_1;
     private String ENCRYPTED_SECRET_2;
@@ -132,6 +133,13 @@ class SecretManagerTest {
             add(secret1);
             add(secret2);
             add(secret3);
+        }};
+    }
+
+    private List<SecretConfiguration> getMockSecretsWithPartialArn() {
+        SecretConfiguration secret = SecretConfiguration.builder().arn(PARTIAL_ARN).build();
+        return new ArrayList<SecretConfiguration>() {{
+            add(secret);
         }};
     }
 
@@ -274,6 +282,28 @@ class SecretManagerTest {
 
         assertNull(getSecretValueResult.getSecretValue().getSecretString());
         assertArrayEquals(SECRET_VALUE_BINARY_3, getSecretValueResult.getSecretValue().getSecretBinary());
+    }
+
+    @Test
+    void GIVEN_secret_manager_WHEN_sync_from_cloud_with_partial_arn_THEN_secrets_are_loaded() throws Exception {
+        when(mockAWSSecretClient.getSecret(any())).thenReturn(getMockSecretA()).thenReturn(getMockSecretB());
+        List<AWSSecretResponse> storedSecrets = new ArrayList<>();
+        storedSecrets.add(getMockDaoSecretA());
+        when(mockDao.getAll()).thenReturn(SecretDocument.builder().secrets(storedSecrets).build());
+        SecretManager sm = new SecretManager(mockAWSSecretClient, crypter, mockDao);
+        sm.syncFromCloud(getMockSecretsWithPartialArn());
+
+        software.amazon.awssdk.aws.greengrass.model.GetSecretValueRequest request =
+                new software.amazon.awssdk.aws.greengrass.model.GetSecretValueRequest();
+        request.setSecretId(SECRET_NAME_1);
+        software.amazon.awssdk.aws.greengrass.model.GetSecretValueResponse getSecretValueResult = sm.getSecret(request);
+
+        assertArrayEquals(SECRET_VALUE_BINARY_1, getSecretValueResult.getSecretValue().getSecretBinary());
+        assertEquals(ARN_1, getSecretValueResult.getSecretId());
+        assertEquals(SECRET_VERSION_1, getSecretValueResult.getVersionId());
+        assertEquals(2, getSecretValueResult.getVersionStage().size());
+        assertEquals(LATEST_LABEL, getSecretValueResult.getVersionStage().get(0));
+        assertEquals(SECRET_LABEL_1, getSecretValueResult.getVersionStage().get(1));
     }
 
     @Test


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Allow regular expression so secrets with a single word and partial arn can be validated using regex.

**Why is this change necessary:**
Partial secrets whose name does not contain a `-` does not pass validation with current regex.

**How was this change tested:**
Unit tests

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
