### PR TITLE
feat: support refreshing secret via ipc req

### DIFF
--- a/src/main/java/com/aws/greengrass/secretmanager/store/SecretStore.java
+++ b/src/main/java/com/aws/greengrass/secretmanager/store/SecretStore.java
@@ -6,6 +6,7 @@
 package com.aws.greengrass.secretmanager.store;
 
 import com.aws.greengrass.secretmanager.exception.SecretManagerException;
+import com.fasterxml.jackson.core.JsonProcessingException;
 
 public interface SecretStore<V, T> {
     V getAll() throws SecretManagerException;
@@ -13,4 +14,6 @@ public interface SecretStore<V, T> {
     void saveAll(V list) throws SecretManagerException;
 
     T get(String secretArn, String label) throws SecretManagerException;
+
+    void save(T encryptedResult) throws SecretManagerException, JsonProcessingException;
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- When the IPC request arg is set to refresh the secret, secret manager tries to get the secret from cloud. 
- It then updates the local store and cache. 
- Secret response is always returned from cache. 
- If the cloud request fails for any reason, existing secret from cache is returned. 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
