### PR TITLE
fix: update secrets with proper labels

### DIFF
--- a/src/main/java/com/aws/greengrass/secretmanager/LocalStoreMap.java
+++ b/src/main/java/com/aws/greengrass/secretmanager/LocalStoreMap.java
@@ -1,0 +1,303 @@
+package com.aws.greengrass.secretmanager;
+
+import com.aws.greengrass.config.Node;
+import com.aws.greengrass.deployment.DeviceConfiguration;
+import com.aws.greengrass.logging.api.Logger;
+import com.aws.greengrass.logging.impl.LogManager;
+import com.aws.greengrass.secretmanager.crypto.Crypter;
+import com.aws.greengrass.secretmanager.crypto.KeyChain;
+import com.aws.greengrass.secretmanager.crypto.MasterKey;
+import com.aws.greengrass.secretmanager.crypto.RSAMasterKey;
+import com.aws.greengrass.secretmanager.exception.SecretCryptoException;
+import com.aws.greengrass.secretmanager.exception.SecretManagerException;
+import com.aws.greengrass.secretmanager.model.AWSSecretResponse;
+import com.aws.greengrass.secretmanager.model.SecretConfiguration;
+import com.aws.greengrass.secretmanager.model.SecretDocument;
+import com.aws.greengrass.secretmanager.store.FileSecretStore;
+import com.aws.greengrass.secretmanager.store.SecretStore;
+import com.aws.greengrass.security.SecurityService;
+import com.aws.greengrass.security.exceptions.ServiceUnavailableException;
+import com.aws.greengrass.util.Coerce;
+import com.aws.greengrass.util.LockFactory;
+import com.aws.greengrass.util.LockScope;
+import com.aws.greengrass.util.RetryUtils;
+import com.aws.greengrass.util.Utils;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Lock;
+import javax.inject.Inject;
+
+import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_CERTIFICATE_FILE_PATH;
+import static com.aws.greengrass.deployment.DeviceConfiguration.DEVICE_PARAM_PRIVATE_KEY_PATH;
+
+public class LocalStoreMap {
+    private final Logger logger = LogManager.getLogger(LocalStoreMap.class);
+    private final ConcurrentHashMap<String, Labels> secrets;
+    private final SecretStore<SecretDocument, AWSSecretResponse> secretStore;
+    private final AtomicReference<Crypter> crypter = new AtomicReference<>();
+    private final SecurityService securityService;
+
+    private final Lock lock = LockFactory.newReentrantLock(this);
+
+    @Inject
+    LocalStoreMap(SecurityService securityService, FileSecretStore dao, DeviceConfiguration deviceConfiguration) {
+        this.secretStore = dao;
+        this.securityService = securityService;
+        deviceConfiguration.onAnyChange(((whatHappened, node) -> {
+            if (validUpdate(node, DEVICE_PARAM_CERTIFICATE_FILE_PATH) || validUpdate(node,
+                    DEVICE_PARAM_PRIVATE_KEY_PATH)) {
+                // TODO: If the device creds change, then cache and local store should be updated as well as the keys
+                //  used for encrypting and decrypting the secrets have changed.
+                try (LockScope ls = LockScope.lock(lock)) {
+                    crypter.set(null);
+                }
+            }
+        }));
+        this.secrets = new ConcurrentHashMap<>();
+    }
+
+    private boolean validUpdate(Node node, String key) {
+        return node != null && node.childOf(key) && Utils.isNotEmpty(Coerce.toString(node));
+    }
+
+    protected Crypter getCrypter() throws SecretCryptoException {
+        try (LockScope ls = LockScope.lock(lock)) {
+            if (crypter.get() == null) {
+                try {
+                    loadCrypter();
+                } catch (Exception e) {
+                    throw new SecretCryptoException("Unable to load crypter", e);
+                }
+            }
+            return crypter.get();
+        }
+    }
+
+    private void loadCrypter() throws Exception {
+        try {
+            URI privateKeyUri = securityService.getDeviceIdentityPrivateKeyURI();
+            URI certUri = securityService.getDeviceIdentityCertificateURI();
+            KeyPair kp = RetryUtils.runWithRetry(
+                    RetryUtils.RetryConfig.builder().maxRetryInterval(Duration.ofSeconds(30))
+                            .initialRetryInterval(Duration.ofSeconds(10)).maxAttempt(10)
+                            .retryableExceptions(Collections.singletonList(ServiceUnavailableException.class)).build(),
+                    () -> securityService.getKeyPair(privateKeyUri, certUri), "get-keypair", logger);
+            MasterKey masterKey = RSAMasterKey.createInstance(kp.getPublic(), kp.getPrivate());
+            KeyChain keyChain = new KeyChain();
+            keyChain.addMasterKey(masterKey);
+            crypter.set(new Crypter(keyChain));
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    public void syncWithConfig(List<SecretConfiguration> secretConfiguration) {
+        reloadSecretsFromLocalStore();
+        save(secretConfiguration);
+    }
+
+    /**
+    Downloaded secrets are added to the local store based on the component configuration only.
+    Cache should be updated whenever the store is updated.
+     */
+    private void save(List<SecretConfiguration> secretConfiguration) {
+        List<AWSSecretResponse> responses = new ArrayList<>();
+        if (!secrets.isEmpty()) {
+            secretConfiguration.forEach((secretConfig) -> {
+                secretConfig.getLabels().forEach((label) -> {
+                    String arn = secretConfig.getArn();
+                    if (secrets.containsKey(arn) && secrets.get(arn).responseMap.containsKey(label)) {
+                        responses.add(secrets.get(arn).responseMap.get(label));
+                    }
+                });
+            });
+        }
+
+        try {
+            // update cache whenever the store is updated.
+            secretStore.saveAll(new SecretDocument(responses));
+        } catch (SecretManagerException e) {
+            logger.atError().log("Unable to update the local store.");
+        }
+    }
+
+
+    /**
+     *  {
+     * "secret1-arn" :{
+     *  "AWSCURRENT":{"name": "secret1", "arn": "secret1-arn", "versionId": "secret1-v1", versionStages:["AWSCURRENT"]},
+     *  "NEW" : {"name": "secret1", "arn": "secret1-arn", "versionId": "secret1-v2", versionStages:["NEW", "LATEST"]},
+     *  "LATEST": {"name": "secret1", "arn": "secret1-arn", "versionId": "secret1-v2", versionStages:["NEW", "LATEST"]}
+     *     }
+     * "secret2-arn" :{
+     *  "AWSCURRENT":{"name": "secret2", "arn": "secret2-arn", "versionId": "secret2-v1", versionStages:["AWSCURRENT"]}
+     *  }
+     * }
+     * When a latest secret with "NEW" stage is downloaded from cloud, if "NEW" points to version "secret1-v3"
+     * and "LATEST" still points to "secret1-v2".
+     * Case 1: LATEST label secret is downloaded, downloading NEW failed.
+     * "secret1-arn" :{
+     *  "AWSCURRENT":{"name": "secret1", "arn": "secret1-arn", "versionId": "secret1-v1", versionStages:["AWSCURRENT"]},
+     *  "LATEST": {"name": "secret1", "arn": "secret1-arn", "versionId": "secret1-v2", versionStages:["LATEST"]}
+     *     }
+     *     ..
+     *  Case 2: NEW label secret is downloaded, downloading LATEST failed.
+     * "secret1-arn" :{
+     *  "AWSCURRENT":{"name": "secret1", "arn": "secret1-arn", "versionId": "secret1-v1", versionStages:["AWSCURRENT"]},
+     *  "NEW" : {"name": "secret1", "arn": "secret1-arn", "versionId": "secret1-v2", versionStages:["NEW"]},
+     *  "LATEST": {"name": "secret1", "arn": "secret1-arn", "versionId": "secret1-v2", versionStages:["LATEST"]}
+     *     }
+     *     ..
+     * }
+     * @param result secret response to encrypt
+     * @param secretConfiguration secret manager component configuration
+     * @throws SecretCryptoException when encryption fails
+     */
+    public void updateWithSecret(GetSecretValueResponse result, List<SecretConfiguration> secretConfiguration)
+            throws SecretCryptoException {
+        AWSSecretResponse secretResponse = encryptAWSResponse(result);
+        updateWithSecret(secretResponse, secretConfiguration);
+    }
+
+    private void updateWithSecret(AWSSecretResponse secretResponse, List<SecretConfiguration> secretConfiguration) {
+        reloadSecretsFromLocalStore();
+        String arn = secretResponse.getArn();
+        if (secrets.containsKey(arn)) {
+            Labels secLabelMap = secrets.get(arn);
+            secLabelMap.responseMap.entrySet()
+                    .removeIf(entry -> entry.getValue().getVersionId().equals(secretResponse.getVersionId()));
+            secLabelMap.responseMap.forEach((k, v) -> {
+                ArrayList<String> list = new ArrayList<>(v.getVersionStages());
+                list.removeAll(new ArrayList<>(secretResponse.getVersionStages()));
+                v.setVersionStages(list);
+            });
+        }
+        secrets.putIfAbsent(arn, new Labels(new HashMap<>()));
+        secretResponse.getVersionStages().forEach((label) -> {
+            secrets.get(arn).responseMap.put(label, secretResponse);
+        });
+        this.save(secretConfiguration);
+    }
+
+    private AWSSecretResponse encryptAWSResponse(GetSecretValueResponse result) throws SecretCryptoException {
+        String encodedSecretString = null;
+        if (result.secretString() != null) {
+            byte[] encryptedSecretString =
+                    getCrypter().encrypt(result.secretString().getBytes(StandardCharsets.UTF_8), result.arn());
+            encodedSecretString = Base64.getEncoder().encodeToString(encryptedSecretString);
+        }
+        String encodedSecretBinary = null;
+        if (result.secretBinary() != null) {
+            byte[] encryptedSecretBinary = getCrypter().encrypt(result.secretBinary().asByteArray(), result.arn());
+            encodedSecretBinary = Base64.getEncoder().encodeToString(encryptedSecretBinary);
+        }
+        // reuse all fields except the secret value, replace secret value with encrypted value
+        return AWSSecretResponse.builder().encryptedSecretString(encodedSecretString)
+                .encryptedSecretBinary(encodedSecretBinary).name(result.name()).arn(result.arn())
+                .createdDate(result.createdDate().toEpochMilli()).versionId(result.versionId())
+                .versionStages(result.versionStages()).build();
+    }
+
+    /**
+     * Decrypt encrypted secret response to IPC GetSecretValueResponse object.
+     * @param awsSecretResponse encrypted secret
+     * @return IPC GetSecretValueResponse structure
+     * @throws SecretCryptoException crypto exception
+     */
+    public GetSecretValueResponse decrypt(AWSSecretResponse awsSecretResponse) throws SecretCryptoException {
+        String decryptedSecretString = null;
+        if (awsSecretResponse.getEncryptedSecretString() != null) {
+            byte[] decryptedSecret =
+                    getCrypter().decrypt(Base64.getDecoder().decode(awsSecretResponse.getEncryptedSecretString()),
+                            awsSecretResponse.getArn());
+            decryptedSecretString = new String(decryptedSecret, StandardCharsets.UTF_8);
+        }
+
+        SdkBytes decryptedSecretBinary = null;
+        if (awsSecretResponse.getEncryptedSecretBinary() != null) {
+            byte[] decryptedSecret =
+                    getCrypter().decrypt(Base64.getDecoder().decode(awsSecretResponse.getEncryptedSecretBinary()),
+                            awsSecretResponse.getArn());
+            decryptedSecretBinary = SdkBytes.fromByteArray(decryptedSecret);
+        }
+
+        return GetSecretValueResponse.builder().secretString(decryptedSecretString).secretBinary(decryptedSecretBinary)
+                .name(awsSecretResponse.getName()).arn(awsSecretResponse.getArn())
+                .createdDate(Instant.ofEpochMilli(awsSecretResponse.getCreatedDate()))
+                .versionId(awsSecretResponse.getVersionId()).versionStages(awsSecretResponse.getVersionStages())
+                .build();
+    }
+
+    /**
+     * Store secrets map.
+     * For the given secrets manager configuration
+     * {
+     * "cloudSecrets":[
+     *     {"arn":"secret1-arn", "labels":["AWSCURRENT", "NEW"]},
+     *     {"arn":"secret2-arn", "labels":["AWSCURRENT"]}
+     *   ]
+     * }
+     * Local store (runtime config) contains secrets in the following format
+     * [secrets:
+     * {"name": "secret1", "arn": "secret1-arn", "versionId": "secret1-v1", versionStages:["AWSCURRENT"]},
+     * {"name": "secret1", "arn": "secret1-arn", "versionId": "secret1-v2", versionStages:["NEW", "LATEST"]},
+     * {"name": "secret2", "arn": "secret2-arn", "versionId": "secret2-v1", versionStages:["AWSCURRENT"]}
+     * ]
+     * The following method returns the following structure for the same secrets only when decrypting the secret is
+     * successful
+     * {
+     * "secret1-arn" :{
+     *  "AWSCURRENT":{"name": "secret1", "arn": "secret1-arn", "versionId": "secret1-v1", versionStages:["AWSCURRENT"]},
+     *  "NEW" : {"name": "secret1", "arn": "secret1-arn", "versionId": "secret1-v2", versionStages:["NEW", "LATEST"]},
+     *  "LATEST": {"name": "secret1", "arn": "secret1-arn", "versionId": "secret1-v2", versionStages:["NEW", "LATEST"]}
+     * }
+     * "secret2-arn" : {
+     *   "AWSCURRENT":{"name": "secret2", "arn": "secret2-arn", "versionId": "secret2-v1", versionStages:["AWSCURRENT"]}
+     *  }
+     * }
+     */
+    private void reloadSecretsFromLocalStore() {
+        try {
+            SecretDocument doc = secretStore.getAll();
+            if (doc == null || doc.getSecrets() == null || doc.getSecrets().isEmpty()) {
+                return;
+            }
+            for (AWSSecretResponse secretResponse : doc.getSecrets()) {
+                try {
+                    decrypt(secretResponse);
+                } catch (SecretCryptoException e) {
+                    logger.atInfo().kv("secretArn", secretResponse.getArn()).kv("label", secretResponse.getVersionId())
+                            .log("Unable to decrypt the secret in local store.");
+                    continue;
+                }
+                secrets.putIfAbsent(secretResponse.getArn(), new Labels(new HashMap<>()));
+                secretResponse.getVersionStages().forEach((label) -> {
+                    secrets.get(secretResponse.getArn()).responseMap.put(label, secretResponse);
+                });
+            }
+        } catch (SecretManagerException e) {
+            logger.atWarn().log("Cannot read secrets from the local store");
+        }
+    }
+
+    public static class Labels {
+        HashMap<String, AWSSecretResponse> responseMap;
+
+        public Labels(HashMap<String, AWSSecretResponse> responseMap) {
+            this.responseMap = responseMap;
+        }
+    }
+}

--- a/src/main/java/com/aws/greengrass/secretmanager/SecretManagerService.java
+++ b/src/main/java/com/aws/greengrass/secretmanager/SecretManagerService.java
@@ -147,7 +147,7 @@ public class SecretManagerService extends PluginService {
             // Ignore. This means we started with empty configuration
             logger.atDebug().setEventType("secret-manager-startup").log("No secrets configured");
         } catch (SecretManagerException e) {
-            // No need to log anything here, it is already logged by loadSecretsFromLocalStore
+            // No need to log anything here, it is already logged by reloadCache
 
             // If there was a crypto issue then we probably need to re-encrypt the secrets, so we will wait for the sync
             // future to complete without error since it would have started up already due to the subscribe() call

--- a/src/main/java/com/aws/greengrass/secretmanager/SecretManagerService.java
+++ b/src/main/java/com/aws/greengrass/secretmanager/SecretManagerService.java
@@ -30,6 +30,7 @@ import software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -92,35 +93,8 @@ public class SecretManagerService extends PluginService {
         this.config.lookupTopics(CONFIGURATION_CONFIG_KEY).subscribe(this.handleConfigurationChangeLambda);
     }
 
-    private void syncFromCloud() throws SecretManagerException, InterruptedException {
-        Topic secretParam = this.config.lookup(CONFIGURATION_CONFIG_KEY, SECRETS_TOPIC);
-        try {
-            List<SecretConfiguration> configuredSecrets = OBJECT_MAPPER.convertValue(secretParam.toPOJO(),
-                    new TypeReference<List<SecretConfiguration>>() {
-                    });
-            if (configuredSecrets != null) {
-                secretManager.syncFromCloud(configuredSecrets);
-            } else {
-                logger.atError().kv("secrets", secretParam.toString()).log("Unable to parse secrets configured");
-            }
-        } catch (IllegalArgumentException e) {
-            logger.atError().kv("node", secretParam.getFullName())
-                    .kv("value", secretParam).setCause(e).log("Unable to parse secrets configured");
-        }
-    }
-
     private void serviceChanged() {
-        replaceSyncFuture(() -> {
-            try {
-                this.syncFromCloud();
-            } catch (SecretManagerException e) {
-                logger.atWarn().kv("service", SECRET_MANAGER_SERVICE_NAME).setCause(e)
-                        .log("Unable to download secrets from cloud");
-                serviceErrored(e);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
-        });
+        replaceSyncFuture(secretManager::syncFromCloud);
     }
 
     private synchronized Future<?> replaceSyncFuture(Runnable r) {
@@ -168,7 +142,7 @@ public class SecretManagerService extends PluginService {
         // We don't want to load anything if there is no file, which could happen when
         // we were not able to download any secrets due to network issues.
         try {
-            secretManager.loadSecretsFromLocalStore();
+            secretManager.reloadCache();
         } catch (NoSecretFoundException e) {
             // Ignore. This means we started with empty configuration
             logger.atDebug().setEventType("secret-manager-startup").log("No secrets configured");

--- a/src/test/java/com/aws/greengrass/secretmanager/SecretManagerServiceIntegTest.java
+++ b/src/test/java/com/aws/greengrass/secretmanager/SecretManagerServiceIntegTest.java
@@ -179,6 +179,7 @@ public class SecretManagerServiceIntegTest extends BaseITCase {
     @Test
     void GIVEN_secret_service_And_device_config_changes_throw_ex_When_ipc_handler_with_refresh_called_THEN_return_from_cache(ExtensionContext context) throws Exception {
         ignoreExceptionOfType(context, SecretCryptoException.class);
+        ignoreExceptionOfType(context, GetSecretException.class);
         startKernelWithConfig("config.yaml", State.RUNNING);
         lenient().doThrow(KeyLoadingException.class).when(mockSecurityService).getKeyPair(any(),
                 any());

--- a/src/test/java/com/aws/greengrass/secretmanager/SecretManagerServiceTest.java
+++ b/src/test/java/com/aws/greengrass/secretmanager/SecretManagerServiceTest.java
@@ -114,7 +114,7 @@ public class SecretManagerServiceTest {
     void GIVEN_secret_service_WHEN_load_secret_fails_THEN_service_errors(ExtensionContext context) throws Exception {
         ignoreExceptionOfType(context, SecretManagerException.class);
 
-        doThrow(SecretManagerException.class).when(mockSecretManager).loadSecretsFromLocalStore();
+        doThrow(SecretManagerException.class).when(mockSecretManager).reloadCache();
         startKernelWithConfig("config.yaml", State.ERRORED);
     }
 
@@ -123,9 +123,9 @@ public class SecretManagerServiceTest {
         ignoreExceptionOfType(context, SecretManagerException.class);
 
         SecretManagerException ex = new SecretManagerException(new SecretCryptoException("Bad"));
-        doThrow(ex).when(mockSecretManager).loadSecretsFromLocalStore();
+        doThrow(ex).when(mockSecretManager).reloadCache();
         startKernelWithConfig("config.yaml", State.RUNNING);
-        verify(mockSecretManager).syncFromCloud(any());
+        verify(mockSecretManager).syncFromCloud();
     }
 
     private com.aws.greengrass.secretmanager.model.v1.GetSecretValueResult convertSecret(byte[] bytes)

--- a/src/test/java/com/aws/greengrass/secretmanager/SecretManagerTest.java
+++ b/src/test/java/com/aws/greengrass/secretmanager/SecretManagerTest.java
@@ -7,6 +7,8 @@ package com.aws.greengrass.secretmanager;
 
 import com.aws.greengrass.config.Configuration;
 import com.aws.greengrass.config.Topic;
+import com.aws.greengrass.config.UnsupportedInputTypeException;
+import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.deployment.DeviceConfiguration;
 import com.aws.greengrass.secretmanager.crypto.Crypter;
 import com.aws.greengrass.secretmanager.crypto.KeyChain;
@@ -23,6 +25,7 @@ import com.aws.greengrass.secretmanager.store.FileSecretStore;
 import com.aws.greengrass.security.SecurityService;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.util.EncryptionUtils;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -53,6 +56,8 @@ import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
+import static com.aws.greengrass.secretmanager.SecretManagerService.SECRETS_TOPIC;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
@@ -60,8 +65,10 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -89,6 +96,8 @@ class SecretManagerTest {
     private static final String SECRET_VERSION_3 = UUID.randomUUID().toString();
     private static final String SECRET_LABEL_1 = "Label1";
     private static final String SECRET_LABEL_2 = "Label2";
+    private static final String SECRET_LABEL_3 = "Label3";
+
     private static final Instant SECRET_DATE_1 = Instant.now();
     private static final Instant SECRET_DATE_2 = Instant.now();
 
@@ -114,6 +123,8 @@ class SecretManagerTest {
     @Mock
     private DeviceConfiguration mockDeviceConfiguration;
 
+    private LocalStoreMap localStoreMap;
+
     @Mock
     private KernelClient mockKernelClient;
 
@@ -127,23 +138,30 @@ class SecretManagerTest {
     @Captor
     ArgumentCaptor<software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest> awsClientRequestCaptor;
 
-    private List<SecretConfiguration> getMockSecrets() {
+    private void getMockSecrets() throws JsonProcessingException, UnsupportedInputTypeException {
         SecretConfiguration secret1 = SecretConfiguration.builder().arn(ARN_1).build();
         SecretConfiguration secret2 = SecretConfiguration.builder().arn(ARN_2)
                 .labels(Arrays.asList(LATEST_LABEL, SECRET_LABEL_1)).build();
         SecretConfiguration secret3 = SecretConfiguration.builder().arn(ARN_3).build();
-        return new ArrayList<SecretConfiguration>() {{
+        ArrayList<SecretConfiguration> config_ = new ArrayList<SecretConfiguration>() {{
             add(secret1);
             add(secret2);
             add(secret3);
         }};
+        Configuration config = new Configuration(new Context());
+        config.lookupTopics("services", SecretManagerService.SECRET_MANAGER_SERVICE_NAME)
+                .lookup(CONFIGURATION_CONFIG_KEY, SECRETS_TOPIC).withValueChecked(config_);
+        doReturn(config).when(mockKernelClient).getConfig();
     }
 
-    private List<SecretConfiguration> getMockSecretsWithPartialArn() {
+    private void getMockSecretsWithPartialArn() throws UnsupportedInputTypeException {
         SecretConfiguration secret = SecretConfiguration.builder().arn(PARTIAL_ARN).build();
-        return new ArrayList<SecretConfiguration>() {{
-            add(secret);
-        }};
+        Configuration config = new Configuration(new Context());
+        config.lookupTopics("services", SecretManagerService.SECRET_MANAGER_SERVICE_NAME)
+                .lookup(CONFIGURATION_CONFIG_KEY, SECRETS_TOPIC).withValueChecked(new ArrayList<SecretConfiguration>() {{
+                    add(secret);
+                }});
+        doReturn(config).when(mockKernelClient).getConfig();
     }
 
     @AfterEach
@@ -176,6 +194,7 @@ class SecretManagerTest {
         ENCRYPTED_SECRET_BINARY_1 = Base64.getEncoder().encodeToString(crypter.encrypt(SECRET_VALUE_BINARY_1, ARN_1));
         ENCRYPTED_SECRET_BINARY_2 = Base64.getEncoder().encodeToString(crypter.encrypt(SECRET_VALUE_BINARY_2, ARN_2));
         ENCRYPTED_SECRET_BINARY_3 = Base64.getEncoder().encodeToString(crypter.encrypt(SECRET_VALUE_BINARY_3, ARN_3));
+        localStoreMap = new LocalStoreMap(mockSecurityService, mockDao, mockDeviceConfiguration);
     }
 
     private GetSecretValueResponse getMockSecret(String name, String arn, Instant date, String secretString,
@@ -246,12 +265,13 @@ class SecretManagerTest {
     private AWSSecretResponse getMockDaoSecretCWithSecretBinary() {
         return AWSSecretResponse.builder().name(SECRET_NAME_3).arn(ARN_3).createdDate(SECRET_DATE_2.toEpochMilli())
                 .encryptedSecretBinary(ENCRYPTED_SECRET_BINARY_3)
-                .versionStages(Arrays.asList(LATEST_LABEL, SECRET_LABEL_2)).versionId(SECRET_VERSION_2)
+                .versionStages(Arrays.asList(LATEST_LABEL, SECRET_LABEL_3)).versionId(SECRET_VERSION_3)
                 .build();
     }
 
     @Test
     void GIVEN_cloud_secret_WHEN_binary_secret_set_THEN_only_binary_returned() throws Exception {
+        getMockSecrets();
         when(mockAWSSecretClient.getSecret(any()))
                 .thenReturn(getMockSecretAWithSecretString())
                 .thenReturn(getMockSecretBWithSecretBinary())
@@ -260,9 +280,10 @@ class SecretManagerTest {
         storedSecrets.add(getMockDaoSecretAWithSecretString());
         storedSecrets.add(getMockDaoSecretBWithSecretBinary());
         storedSecrets.add(getMockDaoSecretCWithSecretBinary());
-        when(mockDao.getAll()).thenReturn(SecretDocument.builder().secrets(storedSecrets).build());
-        SecretManager sm = new SecretManager(mockAWSSecretClient, mockSecurityService, mockDao, mockDeviceConfiguration);
-        sm.syncFromCloud(getMockSecrets());
+        when(mockDao.getAll())
+                .thenReturn(SecretDocument.builder().secrets(storedSecrets).build());
+        SecretManager sm = new SecretManager(mockAWSSecretClient, mockDao,mockKernelClient, localStoreMap);
+        sm.syncFromCloud();
 
         software.amazon.awssdk.aws.greengrass.model.GetSecretValueRequest request =
                 new software.amazon.awssdk.aws.greengrass.model.GetSecretValueRequest();
@@ -289,12 +310,13 @@ class SecretManagerTest {
 
     @Test
     void GIVEN_secret_manager_WHEN_sync_from_cloud_with_partial_arn_THEN_secrets_are_loaded() throws Exception {
+        getMockSecretsWithPartialArn();
         when(mockAWSSecretClient.getSecret(any())).thenReturn(getMockSecretA()).thenReturn(getMockSecretB());
         List<AWSSecretResponse> storedSecrets = new ArrayList<>();
         storedSecrets.add(getMockDaoSecretA());
         when(mockDao.getAll()).thenReturn(SecretDocument.builder().secrets(storedSecrets).build());
-        SecretManager sm = new SecretManager(mockAWSSecretClient, mockSecurityService, mockDao, mockDeviceConfiguration);
-        sm.syncFromCloud(getMockSecretsWithPartialArn());
+        SecretManager sm = new SecretManager(mockAWSSecretClient, mockDao, mockKernelClient, localStoreMap);
+        sm.syncFromCloud();
 
         software.amazon.awssdk.aws.greengrass.model.GetSecretValueRequest request =
                 new software.amazon.awssdk.aws.greengrass.model.GetSecretValueRequest();
@@ -312,13 +334,14 @@ class SecretManagerTest {
     @Test
     void GIVEN_secret_manager_WHEN_ipc_req_with_refresh_throws_ex_THEN_load_from_cache(ExtensionContext context)
             throws Exception {
+        getMockSecrets();
         ignoreExceptionOfType(context, SecretManagerException.class);
         when(mockAWSSecretClient.getSecret(any())).thenReturn(getMockSecretA()).thenReturn(getMockSecretB());
         List<AWSSecretResponse> storedSecrets = new ArrayList<>();
         storedSecrets.add(getMockDaoSecretA());
         when(mockDao.getAll()).thenReturn(SecretDocument.builder().secrets(storedSecrets).build());
-        SecretManager sm = new SecretManager(mockAWSSecretClient, mockSecurityService, mockDao, mockDeviceConfiguration);
-        sm.syncFromCloud(getMockSecrets());
+        SecretManager sm = new SecretManager(mockAWSSecretClient, mockDao, mockKernelClient, localStoreMap);
+        sm.syncFromCloud();
 
         software.amazon.awssdk.aws.greengrass.model.GetSecretValueRequest request =
                 new software.amazon.awssdk.aws.greengrass.model.GetSecretValueRequest();
@@ -339,13 +362,14 @@ class SecretManagerTest {
 
     @Test
     void GIVEN_secret_manager_WHEN_sync_from_cloud_THEN_secrets_are_loaded() throws Exception {
+        getMockSecrets();
         when(mockAWSSecretClient.getSecret(any())).thenReturn(getMockSecretA()).thenReturn(getMockSecretB());
         List<AWSSecretResponse> storedSecrets = new ArrayList<>();
         storedSecrets.add(getMockDaoSecretA());
         storedSecrets.add(getMockDaoSecretB());
         when(mockDao.getAll()).thenReturn(SecretDocument.builder().secrets(storedSecrets).build());
-        SecretManager sm = new SecretManager(mockAWSSecretClient, mockSecurityService, mockDao, mockDeviceConfiguration);
-        sm.syncFromCloud(getMockSecrets());
+        SecretManager sm = new SecretManager(mockAWSSecretClient, mockDao, mockKernelClient, localStoreMap);
+        sm.syncFromCloud();
 
         software.amazon.awssdk.aws.greengrass.model.GetSecretValueRequest request =
                 new software.amazon.awssdk.aws.greengrass.model.GetSecretValueRequest();
@@ -423,14 +447,15 @@ class SecretManagerTest {
 
     @Test
     void GIVEN_secret_manager_WHEN_sync_from_cloud_THEN_v1_secret_api_works() throws Exception {
+        getMockSecrets();
         when(mockAWSSecretClient.getSecret(any())).thenReturn(getMockSecretAWithSecretString())
                 .thenReturn(getMockSecretBWithSecretBinary());
         List<AWSSecretResponse> storedSecrets = new ArrayList<>();
         storedSecrets.add(getMockDaoSecretAWithSecretString());
         storedSecrets.add(getMockDaoSecretBWithSecretBinary());
         when(mockDao.getAll()).thenReturn(SecretDocument.builder().secrets(storedSecrets).build());
-        SecretManager sm = new SecretManager(mockAWSSecretClient, mockSecurityService, mockDao, mockDeviceConfiguration);
-        sm.syncFromCloud(getMockSecrets());
+        SecretManager sm = new SecretManager(mockAWSSecretClient, mockDao, mockKernelClient, localStoreMap);
+        sm.syncFromCloud();
 
         com.aws.greengrass.secretmanager.model.v1.GetSecretValueRequest request =
                 com.aws.greengrass.secretmanager.model.v1.GetSecretValueRequest.builder().secretId(SECRET_NAME_1)
@@ -520,7 +545,7 @@ class SecretManagerTest {
         ignoreExceptionOfType(context, SecretManagerException.class);
         when(mockDao.getAll()).thenReturn(mock(SecretDocument.class));
         when(mockAWSSecretClient.getSecret(any())).thenReturn(getMockSecretA());
-        SecretManager sm = new SecretManager(mockAWSSecretClient, mockSecurityService, mockDao, mockDeviceConfiguration);
+        SecretManager sm = new SecretManager(mockAWSSecretClient, mockDao,mockKernelClient, localStoreMap);
         String invalidArn = "randomArn";
         SecretConfiguration secret1 = SecretConfiguration.builder().arn(ARN_1).build();
         SecretConfiguration secret2 = SecretConfiguration.builder().arn(invalidArn)
@@ -529,7 +554,11 @@ class SecretManagerTest {
             add(secret1);
             add(secret2);
         }};
-        sm.syncFromCloud(configuredSecrets);
+        Configuration config = new Configuration(new Context());
+        config.lookupTopics("services", SecretManagerService.SECRET_MANAGER_SERVICE_NAME)
+                .lookup(CONFIGURATION_CONFIG_KEY, SECRETS_TOPIC).withValueChecked(configuredSecrets);
+        doReturn(config).when(mockKernelClient).getConfig();
+        sm.syncFromCloud();
 
         // verify that we only called aws cloud for ARN_1 and skipped invalidArn
         verify(mockAWSSecretClient, times(1)).getSecret(awsClientRequestCaptor.capture());
@@ -546,24 +575,27 @@ class SecretManagerTest {
         List<AWSSecretResponse> storedSecrets = new ArrayList<>();
         storedSecrets.add(getMockDaoSecretA());
         when(mockDao.getAll()).thenReturn(SecretDocument.builder().secrets(storedSecrets).build());
-        SecretManager sm = new SecretManager(mockAWSSecretClient, mockSecurityService, mockDao, mockDeviceConfiguration);
+        SecretManager sm = new SecretManager(mockAWSSecretClient, mockDao, mockKernelClient, localStoreMap);
 
         // Load one secret from local and verify
-        sm.loadSecretsFromLocalStore();
+        sm.reloadCache();
         software.amazon.awssdk.aws.greengrass.model.GetSecretValueRequest request =
                 new software.amazon.awssdk.aws.greengrass.model.GetSecretValueRequest();
         request.setSecretId(SECRET_NAME_1);
-        System.out.println(sm.getSecret(request).getSecretId());
         assertEquals(SECRET_VALUE_1, new String(sm.getSecret(request).getSecretValue().getSecretBinary()));
 
+        Configuration config = new Configuration(new Context());
+        config.lookupTopics("services", SecretManagerService.SECRET_MANAGER_SERVICE_NAME)
+                .lookup(CONFIGURATION_CONFIG_KEY, SECRETS_TOPIC).withValueChecked(new ArrayList<>());
+        doReturn(config).when(mockKernelClient).getConfig();
         // Now pass in empty config and assert no secret is saved
-        sm.syncFromCloud(new ArrayList<>());
+        sm.syncFromCloud();
         verify(mockDao, times(1)).saveAll(documentArgumentCaptor.capture());
         assertEquals(0, documentArgumentCaptor.getValue().getSecrets().size());
 
         // Load doc and assert secret removed
         when(mockDao.getAll()).thenReturn(documentArgumentCaptor.getValue());
-        sm.loadSecretsFromLocalStore();
+        sm.reloadCache();
         try {
             sm.getSecret(request);
         } catch (GetSecretException e) {
@@ -575,114 +607,138 @@ class SecretManagerTest {
     @Test
     void GIVEN_secret_manager_WHEN_cloud_errors_THEN_secrets_are_not_loaded(ExtensionContext context) throws Exception {
         ignoreExceptionOfType(context, SecretManagerException.class);
+        ignoreExceptionOfType(context, IOException.class);
+        getMockSecrets();
         when(mockDao.getAll()).thenReturn(mock(SecretDocument.class));
         when(mockAWSSecretClient.getSecret(any())).thenThrow(SecretManagerException.class);
-        SecretManager sm = new SecretManager(mockAWSSecretClient, mockSecurityService, mockDao, mockDeviceConfiguration);
+        SecretManager sm = new SecretManager(mockAWSSecretClient, mockDao,  mockKernelClient, localStoreMap);
         // Secrets should not be loaded as the secret fails and should throw SecretManagerException
-        assertThrows(SecretManagerException.class, () -> sm.syncFromCloud(getMockSecrets()));
-        verify(mockAWSSecretClient, times(1)).getSecret(any());
-        verify(mockDao, times(0)).saveAll(any());
+        sm.syncFromCloud();
+        verify(mockAWSSecretClient, times(4)).getSecret(any());
+        verify(mockDao, times(1)).saveAll(any());
 
         // Now, update the aws client to return a result and then throw SecretManagerException for second secret
         // Secrets should not be loaded as one secret fails and should throw SecretManagerException
         reset(mockAWSSecretClient);
         reset(mockDao);
+        when(mockDao.getAll()).thenReturn(mock(SecretDocument.class));
         when(mockAWSSecretClient.getSecret(any())).thenReturn(getMockSecretA()).thenThrow(SecretManagerException.class);
-        assertThrows(SecretManagerException.class, () -> sm.syncFromCloud(getMockSecrets()));
-        verify(mockAWSSecretClient, times(2)).getSecret(any());
-        verify(mockDao, times(0)).saveAll(any());
+        sm.syncFromCloud();
+
+        verify(mockAWSSecretClient, times(4)).getSecret(any());
+        verify(mockDao, times(2)).saveAll(any());
 
         // Now, update the aws client to return a result and then throw IOException for second secret
         // Secrets should not be loaded as one secret fails and should throw SecretManagerException
         reset(mockAWSSecretClient);
         reset(mockDao);
-        when(mockAWSSecretClient.getSecret(any())).thenReturn(getMockSecretA()).thenThrow(IOException.class);
-        assertThrows(SecretManagerException.class, () -> sm.syncFromCloud(getMockSecrets()));
-        verify(mockAWSSecretClient, times(2)).getSecret(any());
-        verify(mockDao, times(0)).saveAll(any());
-    }
-
-    @Test
-    void GIVEN_secret_manager_WHEN_network_error_and_new_secret_THEN_throws() throws Exception {
-        SecretManager sm = new SecretManager(mockAWSSecretClient, mockSecurityService, mockDao, mockDeviceConfiguration);
-        SecretConfiguration secret1 = SecretConfiguration.builder().arn(ARN_1).build();
-        List<SecretConfiguration> configuredSecret1 = Collections.singletonList(secret1);
-
-        when(mockAWSSecretClient.getSecret(any())).thenThrow(IOException.class);
-        assertThrows(SecretManagerException.class, () -> sm.syncFromCloud(configuredSecret1));
-    }
-
-    @Test
-    void GIVEN_secret_manager_WHEN_network_error_and_existing_secret_THEN_not_throw() throws Exception {
         when(mockDao.getAll()).thenReturn(mock(SecretDocument.class));
-        SecretManager sm = new SecretManager(mockAWSSecretClient, mockSecurityService, mockDao, mockDeviceConfiguration);
+
+        when(mockAWSSecretClient.getSecret(any())).thenReturn(getMockSecretA()).thenThrow(IOException.class);
+        sm.syncFromCloud();
+        verify(mockAWSSecretClient, times(4)).getSecret(any());
+        verify(mockDao, times(2)).saveAll(any());
+    }
+
+    @Test
+    void GIVEN_secret_manager_WHEN_network_error_and_new_secret_THEN_throws(ExtensionContext context) throws Exception {
+        ignoreExceptionOfType(context, IOException.class);
+
+        SecretManager sm = new SecretManager(mockAWSSecretClient, mockDao, mockKernelClient, localStoreMap);
         SecretConfiguration secret1 = SecretConfiguration.builder().arn(ARN_1).build();
-        List<SecretConfiguration> configuredSecret1 = Collections.singletonList(secret1);
+        Configuration config = new Configuration(new Context());
+        config.lookupTopics("services", SecretManagerService.SECRET_MANAGER_SERVICE_NAME)
+                .lookup(CONFIGURATION_CONFIG_KEY, SECRETS_TOPIC).withValueChecked(Collections.singletonList(secret1));
+        doReturn(config).when(mockKernelClient).getConfig();
+        when(mockAWSSecretClient.getSecret(any())).thenThrow(IOException.class);
+        sm.syncFromCloud();
+        verify(mockDao, times(1)).saveAll(any());
+    }
+
+    @Test
+    void GIVEN_secret_manager_WHEN_network_error_and_existing_secret_THEN_not_throw(ExtensionContext context) throws Exception {
+        ignoreExceptionOfType(context, IOException.class);
+        getMockSecrets();
+        when(mockDao.getAll()).thenReturn(SecretDocument.builder().secrets(Collections.singletonList(getMockDaoSecretA())).build());
+
+        SecretManager sm = new SecretManager(mockAWSSecretClient, mockDao, mockKernelClient, localStoreMap);
 
         // Secret is in Dao, IOException is ignored and secret is loaded from local
-        when(mockDao.get(ARN_1, LATEST_LABEL)).thenReturn(getMockDaoSecretA());
         when(mockAWSSecretClient.getSecret(any())).thenThrow(IOException.class);
-        sm.syncFromCloud(configuredSecret1);
-        verify(mockDao, times(1)).saveAll(documentArgumentCaptor.capture());
-        // Now assert that one secret was persisted in the db
-        assertEquals(1, documentArgumentCaptor.getValue().getSecrets().size());
+        sm.syncFromCloud();
+        verify(mockDao, times(1)).saveAll(any());
     }
 
     @Test
-    void GIVEN_secret_manager_WHEN_some_label_error_THEN_throws_for_non_network_error() throws Exception {
-        when(mockDao.getAll()).thenReturn(mock(SecretDocument.class));
-        SecretManager sm = new SecretManager(mockAWSSecretClient, mockSecurityService, mockDao, mockDeviceConfiguration);
+    void GIVEN_secret_manager_WHEN_some_label_error_THEN_throws_for_non_network_error(ExtensionContext context) throws Exception {
+        ignoreExceptionOfType(context, IOException.class);
+        ignoreExceptionOfType(context, SecretManagerException.class);
+
+        SecretManager sm = new SecretManager(mockAWSSecretClient, mockDao, mockKernelClient, localStoreMap);
         SecretConfiguration secret =
                 SecretConfiguration.builder().arn(ARN_2).labels(Arrays.asList(LATEST_LABEL, SECRET_LABEL_1)).build();
-        List<SecretConfiguration> configuredSecret = Collections.singletonList(secret);
-
+        Configuration config = new Configuration(new Context());
+        config.lookupTopics("services", SecretManagerService.SECRET_MANAGER_SERVICE_NAME)
+                .lookup(CONFIGURATION_CONFIG_KEY, SECRETS_TOPIC).withValueChecked(Collections.singletonList(secret));
+        doReturn(config).when(mockKernelClient).getConfig();
         // two labels both throw IOException
         // Given only the first one label is in Dao, IOException is ignored and SecretManagerException is thrown
-        when(mockDao.get(ARN_2, LATEST_LABEL)).thenReturn(getMockDaoSecretB());
-        when(mockDao.get(ARN_2, SECRET_LABEL_1)).thenReturn(null);
+        when(mockDao.getAll()).thenReturn(SecretDocument.builder().secrets(Arrays.asList(getMockDaoSecretB())).build());
         when(mockAWSSecretClient.getSecret(any())).thenThrow(IOException.class).thenThrow(IOException.class);
-        assertThrows(SecretManagerException.class, () -> sm.syncFromCloud(configuredSecret));
-
+        sm.syncFromCloud();
+        verify(mockDao, times(1)).saveAll(documentArgumentCaptor.capture());
+        assertEquals(1, documentArgumentCaptor.getValue().getSecrets().size());
         reset(mockAWSSecretClient);
         reset(mockDao);
         when(mockDao.getAll()).thenReturn(mock(SecretDocument.class));
+        AWSSecretResponse secondSec =
+                AWSSecretResponse.builder().name(SECRET_NAME_2).arn(ARN_2).createdDate(SECRET_DATE_2.toEpochMilli())
+                .encryptedSecretString(ENCRYPTED_SECRET_2).encryptedSecretBinary(ENCRYPTED_SECRET_BINARY_2)
+                .versionStages(Arrays.asList(SECRET_LABEL_1)).versionId(SECRET_VERSION_1)
+                .build();
         // two labels throw IOException and SecretManagerException respectively.
         // Given both labels are in Dao, IOException is ignored and SecretManagerException is thrown
-        when(mockDao.get(ARN_2, LATEST_LABEL)).thenReturn(getMockDaoSecretB());
-        when(mockDao.get(ARN_2, SECRET_LABEL_1)).thenReturn(getMockDaoSecretB());
+        when(mockDao.getAll()).thenReturn(SecretDocument.builder().secrets(Arrays.asList(getMockDaoSecretB(), secondSec)).build());
         when(mockAWSSecretClient.getSecret(any())).thenThrow(IOException.class).thenThrow(SecretManagerException.class);
-        assertThrows(SecretManagerException.class, () -> sm.syncFromCloud(configuredSecret));
-
+        sm.syncFromCloud();
+        verify(mockDao, times(1)).saveAll(documentArgumentCaptor.capture());
+        assertEquals(2, documentArgumentCaptor.getValue().getSecrets().size());
         reset(mockAWSSecretClient);
         reset(mockDao);
         when(mockDao.getAll()).thenReturn(mock(SecretDocument.class));
         // one label succeeds and the other throws IOException and SecretManagerException respectively.
         // Given both labels are in Dao, IOException is ignored and SecretManagerException is thrown
-        when(mockDao.get(ARN_2, LATEST_LABEL)).thenReturn(getMockDaoSecretB());
+        when(mockDao.getAll()).thenReturn(SecretDocument.builder().secrets(Arrays.asList(getMockDaoSecretB(), secondSec)).build());
+
         when(mockAWSSecretClient.getSecret(any())).thenReturn(getMockSecretB()).thenThrow(SecretManagerException.class);
-        assertThrows(SecretManagerException.class, () -> sm.syncFromCloud(configuredSecret));
+        sm.syncFromCloud();
+        verify(mockDao, times(2)).saveAll(documentArgumentCaptor.capture());
+        assertEquals(2, documentArgumentCaptor.getValue().getSecrets().size());
 
         reset(mockAWSSecretClient);
         reset(mockDao);
-        when(mockDao.getAll()).thenReturn(mock(SecretDocument.class));
         // one label succeeds and the other throws IOException and SecretManagerException respectively.
         // Given both labels are in Dao, IOException is ignored and secret is loaded from local
-        when(mockDao.get(ARN_2, LATEST_LABEL)).thenReturn(getMockDaoSecretB());
+        when(mockDao.getAll()).thenReturn(SecretDocument.builder().secrets(Arrays.asList(getMockDaoSecretB(), secondSec)).build());
+
         when(mockAWSSecretClient.getSecret(any())).thenReturn(getMockSecretB()).thenThrow(IOException.class);
-        sm.syncFromCloud(configuredSecret);
-        verify(mockDao, times(1)).saveAll(documentArgumentCaptor.capture());
-        // Now assert that both secret persisted in the db
+        sm.syncFromCloud();
+        verify(mockDao, times(2)).saveAll(documentArgumentCaptor.capture());
         assertEquals(2, documentArgumentCaptor.getValue().getSecrets().size());
     }
 
+
     @Test
-    void GIVEN_secret_manager_WHEN_load_from_disk_fails_THEN_throws() throws Exception {
+    void GIVEN_secret_manager_WHEN_load_from_disk_fails_THEN_throws(ExtensionContext context) throws Exception {
+        ignoreExceptionOfType(context, SecretManagerException.class);
+
+        getMockSecrets();
         when(mockAWSSecretClient.getSecret(any())).thenReturn(getMockSecretA());
         doThrow(SecretManagerException.class).when(mockDao).getAll();
 
-        SecretManager sm = new SecretManager(mockAWSSecretClient, mockSecurityService, mockDao, mockDeviceConfiguration);
-        assertThrows(SecretManagerException.class, () -> sm.syncFromCloud(getMockSecrets()));
-        assertThrows(SecretManagerException.class, sm::loadSecretsFromLocalStore);
+        SecretManager sm = new SecretManager(mockAWSSecretClient, mockDao, mockKernelClient, localStoreMap);
+        sm.syncFromCloud();
+        assertThrows(SecretManagerException.class, sm::reloadCache);
     }
 
     @Test
@@ -698,46 +754,34 @@ class SecretManagerTest {
         SecretDocument diskSecrets = SecretDocument.builder().secrets(listSecrets).build();
         when(mockDao.getAll()).thenReturn(diskSecrets);
 
-        SecretManager sm = new SecretManager(mockAWSSecretClient, mockSecurityService, mockDao, mockDeviceConfiguration);
+        SecretManager sm = new SecretManager(mockAWSSecretClient, mockDao, mockKernelClient, localStoreMap);
         // This will throw as encrypted string is invalid format for crypter
-        assertThrows(SecretManagerException.class, sm::loadSecretsFromLocalStore);
+        assertThrows(SecretManagerException.class, sm::reloadCache);
     }
 
     @Test
     void GIVEN_secret_manager_WHEN_sync_from_cloud_THEN_default_label_always_downloaded(ExtensionContext context)
             throws Exception {
+        getMockSecrets();
         ignoreExceptionOfType(context, SecretManagerException.class);
         when(mockDao.getAll()).thenReturn(mock(SecretDocument.class));
         when(mockAWSSecretClient.getSecret(awsClientRequestCaptor.capture())).thenReturn(getMockSecretA())
                 .thenReturn(getMockSecretB());
-        SecretManager sm = new SecretManager(mockAWSSecretClient, mockSecurityService, mockDao, mockDeviceConfiguration);
-        sm.syncFromCloud(getMockSecrets());
-        verify(mockDao, times(1)).saveAll(documentArgumentCaptor.capture());
+
+        SecretManager sm = new SecretManager(mockAWSSecretClient, mockDao, mockKernelClient, localStoreMap);
+        sm.syncFromCloud();
+        verify(mockDao, times(5)).saveAll(documentArgumentCaptor.capture());
 
         List<software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest> awsRequests =
                 awsClientRequestCaptor.getAllValues();
         assertEquals(4, awsRequests.size());
-        assertEquals(LATEST_LABEL, awsRequests.get(0).versionStage());
-        assertEquals(ARN_1, awsRequests.get(0).secretId());
-        assertEquals(SECRET_LABEL_1, awsRequests.get(1).versionStage());
-        assertEquals(ARN_2, awsRequests.get(2).secretId());
-        assertEquals(LATEST_LABEL, awsRequests.get(2).versionStage());
-        assertEquals(ARN_2, awsRequests.get(2).secretId());
-        assertEquals(LATEST_LABEL, awsRequests.get(3).versionStage());
-        assertEquals(ARN_3, awsRequests.get(3).secretId());
-    }
-
-    @Test
-    void GIVEN_secret_manager_WHEN_invalid_key_THEN_secret_manager_not_instantiated() throws URISyntaxException {
-        reset(mockKernelClient);
-        when(mockSecurityService.getDeviceIdentityPrivateKeyURI()).thenReturn(new URI("file:///tmp"));
-        SecretManager manager = new SecretManager(mockAWSSecretClient, mockSecurityService, mockDao, mockDeviceConfiguration);
-        assertThrows(SecretCryptoException.class, manager::getCrypter);
+        assertEquals(3, awsRequests.stream().filter(r->r.versionStage().equals(LATEST_LABEL)).count());
     }
 
     @Test
     void GIVEN_secret_manager_WHEN_get_called_with_invalid_request_THEN_proper_errors_are_returned() throws Exception {
-        SecretManager sm = new SecretManager(mockAWSSecretClient, mockSecurityService, mockDao, mockDeviceConfiguration);
+        getMockSecrets();
+        SecretManager sm = new SecretManager(mockAWSSecretClient,mockDao,mockKernelClient, localStoreMap);
         software.amazon.awssdk.aws.greengrass.model.GetSecretValueRequest request =
                 new software.amazon.awssdk.aws.greengrass.model.GetSecretValueRequest();
         try {
@@ -773,7 +817,7 @@ class SecretManagerTest {
         storedSecrets.add(getMockDaoSecretA());
         storedSecrets.add(getMockDaoSecretB());
         when(mockDao.getAll()).thenReturn(SecretDocument.builder().secrets(storedSecrets).build());
-        sm.syncFromCloud(getMockSecrets());
+        sm.syncFromCloud();
 
         // Create a request for secret with both version and label
         request = new software.amazon.awssdk.aws.greengrass.model.GetSecretValueRequest();

--- a/src/test/java/com/aws/greengrass/secretmanager/SecretManagerTest.java
+++ b/src/test/java/com/aws/greengrass/secretmanager/SecretManagerTest.java
@@ -138,7 +138,7 @@ class SecretManagerTest {
     @Captor
     ArgumentCaptor<software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest> awsClientRequestCaptor;
 
-    private void getMockSecrets() throws JsonProcessingException, UnsupportedInputTypeException {
+    private void loadMockSecrets() throws JsonProcessingException, UnsupportedInputTypeException {
         SecretConfiguration secret1 = SecretConfiguration.builder().arn(ARN_1).build();
         SecretConfiguration secret2 = SecretConfiguration.builder().arn(ARN_2)
                 .labels(Arrays.asList(LATEST_LABEL, SECRET_LABEL_1)).build();
@@ -234,35 +234,35 @@ class SecretManagerTest {
                 Arrays.asList(LATEST_LABEL, SECRET_LABEL_2));
     }
 
-    private AWSSecretResponse getMockDaoSecretA() {
+    private AWSSecretResponse loadMockDaoSecretA() {
         return AWSSecretResponse.builder().name(SECRET_NAME_1).arn(ARN_1).createdDate(SECRET_DATE_1.toEpochMilli())
                 .encryptedSecretString(ENCRYPTED_SECRET_1).encryptedSecretBinary(ENCRYPTED_SECRET_BINARY_1)
                 .versionStages(Arrays.asList(LATEST_LABEL, SECRET_LABEL_1)).versionId(SECRET_VERSION_1)
                 .build();
     }
 
-    private AWSSecretResponse getMockDaoSecretB() {
+    private AWSSecretResponse loadMockDaoSecretB() {
         return AWSSecretResponse.builder().name(SECRET_NAME_2).arn(ARN_2).createdDate(SECRET_DATE_2.toEpochMilli())
                 .encryptedSecretString(ENCRYPTED_SECRET_2).encryptedSecretBinary(ENCRYPTED_SECRET_BINARY_2)
                 .versionStages(Arrays.asList(LATEST_LABEL, SECRET_LABEL_2)).versionId(SECRET_VERSION_2)
                 .build();
     }
 
-    private AWSSecretResponse getMockDaoSecretAWithSecretString() {
+    private AWSSecretResponse loadMockDaoSecretAWithSecretString() {
         return AWSSecretResponse.builder().name(SECRET_NAME_1).arn(ARN_1).createdDate(SECRET_DATE_1.toEpochMilli())
                 .encryptedSecretString(ENCRYPTED_SECRET_1)
                 .versionStages(Arrays.asList(LATEST_LABEL, SECRET_LABEL_1)).versionId(SECRET_VERSION_1)
                 .build();
     }
 
-    private AWSSecretResponse getMockDaoSecretBWithSecretBinary() {
+    private AWSSecretResponse loadMockDaoSecretBWithSecretBinary() {
         return AWSSecretResponse.builder().name(SECRET_NAME_2).arn(ARN_2).createdDate(SECRET_DATE_2.toEpochMilli())
                 .encryptedSecretBinary(ENCRYPTED_SECRET_BINARY_2)
                 .versionStages(Arrays.asList(LATEST_LABEL, SECRET_LABEL_2)).versionId(SECRET_VERSION_2)
                 .build();
     }
 
-    private AWSSecretResponse getMockDaoSecretCWithSecretBinary() {
+    private AWSSecretResponse loadMockDaoSecretCWithSecretBinary() {
         return AWSSecretResponse.builder().name(SECRET_NAME_3).arn(ARN_3).createdDate(SECRET_DATE_2.toEpochMilli())
                 .encryptedSecretBinary(ENCRYPTED_SECRET_BINARY_3)
                 .versionStages(Arrays.asList(LATEST_LABEL, SECRET_LABEL_3)).versionId(SECRET_VERSION_3)
@@ -271,15 +271,15 @@ class SecretManagerTest {
 
     @Test
     void GIVEN_cloud_secret_WHEN_binary_secret_set_THEN_only_binary_returned() throws Exception {
-        getMockSecrets();
+        loadMockSecrets();
         when(mockAWSSecretClient.getSecret(any()))
                 .thenReturn(getMockSecretAWithSecretString())
                 .thenReturn(getMockSecretBWithSecretBinary())
                 .thenReturn(getMockSecretCWithSecretBinary());
         List<AWSSecretResponse> storedSecrets = new ArrayList<>();
-        storedSecrets.add(getMockDaoSecretAWithSecretString());
-        storedSecrets.add(getMockDaoSecretBWithSecretBinary());
-        storedSecrets.add(getMockDaoSecretCWithSecretBinary());
+        storedSecrets.add(loadMockDaoSecretAWithSecretString());
+        storedSecrets.add(loadMockDaoSecretBWithSecretBinary());
+        storedSecrets.add(loadMockDaoSecretCWithSecretBinary());
         when(mockDao.getAll())
                 .thenReturn(SecretDocument.builder().secrets(storedSecrets).build());
         SecretManager sm = new SecretManager(mockAWSSecretClient, mockDao,mockKernelClient, localStoreMap);
@@ -313,7 +313,7 @@ class SecretManagerTest {
         getMockSecretsWithPartialArn();
         when(mockAWSSecretClient.getSecret(any())).thenReturn(getMockSecretA()).thenReturn(getMockSecretB());
         List<AWSSecretResponse> storedSecrets = new ArrayList<>();
-        storedSecrets.add(getMockDaoSecretA());
+        storedSecrets.add(loadMockDaoSecretA());
         when(mockDao.getAll()).thenReturn(SecretDocument.builder().secrets(storedSecrets).build());
         SecretManager sm = new SecretManager(mockAWSSecretClient, mockDao, mockKernelClient, localStoreMap);
         sm.syncFromCloud();
@@ -334,11 +334,11 @@ class SecretManagerTest {
     @Test
     void GIVEN_secret_manager_WHEN_ipc_req_with_refresh_throws_ex_THEN_load_from_cache(ExtensionContext context)
             throws Exception {
-        getMockSecrets();
+        loadMockSecrets();
         ignoreExceptionOfType(context, SecretManagerException.class);
         when(mockAWSSecretClient.getSecret(any())).thenReturn(getMockSecretA()).thenReturn(getMockSecretB());
         List<AWSSecretResponse> storedSecrets = new ArrayList<>();
-        storedSecrets.add(getMockDaoSecretA());
+        storedSecrets.add(loadMockDaoSecretA());
         when(mockDao.getAll()).thenReturn(SecretDocument.builder().secrets(storedSecrets).build());
         SecretManager sm = new SecretManager(mockAWSSecretClient, mockDao, mockKernelClient, localStoreMap);
         sm.syncFromCloud();
@@ -362,11 +362,11 @@ class SecretManagerTest {
 
     @Test
     void GIVEN_secret_manager_WHEN_sync_from_cloud_THEN_secrets_are_loaded() throws Exception {
-        getMockSecrets();
+        loadMockSecrets();
         when(mockAWSSecretClient.getSecret(any())).thenReturn(getMockSecretA()).thenReturn(getMockSecretB());
         List<AWSSecretResponse> storedSecrets = new ArrayList<>();
-        storedSecrets.add(getMockDaoSecretA());
-        storedSecrets.add(getMockDaoSecretB());
+        storedSecrets.add(loadMockDaoSecretA());
+        storedSecrets.add(loadMockDaoSecretB());
         when(mockDao.getAll()).thenReturn(SecretDocument.builder().secrets(storedSecrets).build());
         SecretManager sm = new SecretManager(mockAWSSecretClient, mockDao, mockKernelClient, localStoreMap);
         sm.syncFromCloud();
@@ -447,12 +447,12 @@ class SecretManagerTest {
 
     @Test
     void GIVEN_secret_manager_WHEN_sync_from_cloud_THEN_v1_secret_api_works() throws Exception {
-        getMockSecrets();
+        loadMockSecrets();
         when(mockAWSSecretClient.getSecret(any())).thenReturn(getMockSecretAWithSecretString())
                 .thenReturn(getMockSecretBWithSecretBinary());
         List<AWSSecretResponse> storedSecrets = new ArrayList<>();
-        storedSecrets.add(getMockDaoSecretAWithSecretString());
-        storedSecrets.add(getMockDaoSecretBWithSecretBinary());
+        storedSecrets.add(loadMockDaoSecretAWithSecretString());
+        storedSecrets.add(loadMockDaoSecretBWithSecretBinary());
         when(mockDao.getAll()).thenReturn(SecretDocument.builder().secrets(storedSecrets).build());
         SecretManager sm = new SecretManager(mockAWSSecretClient, mockDao, mockKernelClient, localStoreMap);
         sm.syncFromCloud();
@@ -573,7 +573,7 @@ class SecretManagerTest {
             throws Exception {
         ignoreExceptionOfType(context, SecretManagerException.class);
         List<AWSSecretResponse> storedSecrets = new ArrayList<>();
-        storedSecrets.add(getMockDaoSecretA());
+        storedSecrets.add(loadMockDaoSecretA());
         when(mockDao.getAll()).thenReturn(SecretDocument.builder().secrets(storedSecrets).build());
         SecretManager sm = new SecretManager(mockAWSSecretClient, mockDao, mockKernelClient, localStoreMap);
 
@@ -608,7 +608,7 @@ class SecretManagerTest {
     void GIVEN_secret_manager_WHEN_cloud_errors_THEN_secrets_are_not_loaded(ExtensionContext context) throws Exception {
         ignoreExceptionOfType(context, SecretManagerException.class);
         ignoreExceptionOfType(context, IOException.class);
-        getMockSecrets();
+        loadMockSecrets();
         when(mockDao.getAll()).thenReturn(mock(SecretDocument.class));
         when(mockAWSSecretClient.getSecret(any())).thenThrow(SecretManagerException.class);
         SecretManager sm = new SecretManager(mockAWSSecretClient, mockDao,  mockKernelClient, localStoreMap);
@@ -658,8 +658,8 @@ class SecretManagerTest {
     @Test
     void GIVEN_secret_manager_WHEN_network_error_and_existing_secret_THEN_not_throw(ExtensionContext context) throws Exception {
         ignoreExceptionOfType(context, IOException.class);
-        getMockSecrets();
-        when(mockDao.getAll()).thenReturn(SecretDocument.builder().secrets(Collections.singletonList(getMockDaoSecretA())).build());
+        loadMockSecrets();
+        when(mockDao.getAll()).thenReturn(SecretDocument.builder().secrets(Collections.singletonList(loadMockDaoSecretA())).build());
 
         SecretManager sm = new SecretManager(mockAWSSecretClient, mockDao, mockKernelClient, localStoreMap);
 
@@ -683,7 +683,7 @@ class SecretManagerTest {
         doReturn(config).when(mockKernelClient).getConfig();
         // two labels both throw IOException
         // Given only the first one label is in Dao, IOException is ignored and SecretManagerException is thrown
-        when(mockDao.getAll()).thenReturn(SecretDocument.builder().secrets(Arrays.asList(getMockDaoSecretB())).build());
+        when(mockDao.getAll()).thenReturn(SecretDocument.builder().secrets(Arrays.asList(loadMockDaoSecretB())).build());
         when(mockAWSSecretClient.getSecret(any())).thenThrow(IOException.class).thenThrow(IOException.class);
         sm.syncFromCloud();
         verify(mockDao, times(1)).saveAll(documentArgumentCaptor.capture());
@@ -698,7 +698,7 @@ class SecretManagerTest {
                 .build();
         // two labels throw IOException and SecretManagerException respectively.
         // Given both labels are in Dao, IOException is ignored and SecretManagerException is thrown
-        when(mockDao.getAll()).thenReturn(SecretDocument.builder().secrets(Arrays.asList(getMockDaoSecretB(), secondSec)).build());
+        when(mockDao.getAll()).thenReturn(SecretDocument.builder().secrets(Arrays.asList(loadMockDaoSecretB(), secondSec)).build());
         when(mockAWSSecretClient.getSecret(any())).thenThrow(IOException.class).thenThrow(SecretManagerException.class);
         sm.syncFromCloud();
         verify(mockDao, times(1)).saveAll(documentArgumentCaptor.capture());
@@ -708,7 +708,7 @@ class SecretManagerTest {
         when(mockDao.getAll()).thenReturn(mock(SecretDocument.class));
         // one label succeeds and the other throws IOException and SecretManagerException respectively.
         // Given both labels are in Dao, IOException is ignored and SecretManagerException is thrown
-        when(mockDao.getAll()).thenReturn(SecretDocument.builder().secrets(Arrays.asList(getMockDaoSecretB(), secondSec)).build());
+        when(mockDao.getAll()).thenReturn(SecretDocument.builder().secrets(Arrays.asList(loadMockDaoSecretB(), secondSec)).build());
 
         when(mockAWSSecretClient.getSecret(any())).thenReturn(getMockSecretB()).thenThrow(SecretManagerException.class);
         sm.syncFromCloud();
@@ -719,7 +719,7 @@ class SecretManagerTest {
         reset(mockDao);
         // one label succeeds and the other throws IOException and SecretManagerException respectively.
         // Given both labels are in Dao, IOException is ignored and secret is loaded from local
-        when(mockDao.getAll()).thenReturn(SecretDocument.builder().secrets(Arrays.asList(getMockDaoSecretB(), secondSec)).build());
+        when(mockDao.getAll()).thenReturn(SecretDocument.builder().secrets(Arrays.asList(loadMockDaoSecretB(), secondSec)).build());
 
         when(mockAWSSecretClient.getSecret(any())).thenReturn(getMockSecretB()).thenThrow(IOException.class);
         sm.syncFromCloud();
@@ -732,7 +732,7 @@ class SecretManagerTest {
     void GIVEN_secret_manager_WHEN_load_from_disk_fails_THEN_throws(ExtensionContext context) throws Exception {
         ignoreExceptionOfType(context, SecretManagerException.class);
 
-        getMockSecrets();
+        loadMockSecrets();
         when(mockAWSSecretClient.getSecret(any())).thenReturn(getMockSecretA());
         doThrow(SecretManagerException.class).when(mockDao).getAll();
 
@@ -762,7 +762,7 @@ class SecretManagerTest {
     @Test
     void GIVEN_secret_manager_WHEN_sync_from_cloud_THEN_default_label_always_downloaded(ExtensionContext context)
             throws Exception {
-        getMockSecrets();
+        loadMockSecrets();
         ignoreExceptionOfType(context, SecretManagerException.class);
         when(mockDao.getAll()).thenReturn(mock(SecretDocument.class));
         when(mockAWSSecretClient.getSecret(awsClientRequestCaptor.capture())).thenReturn(getMockSecretA())
@@ -780,7 +780,7 @@ class SecretManagerTest {
 
     @Test
     void GIVEN_secret_manager_WHEN_get_called_with_invalid_request_THEN_proper_errors_are_returned() throws Exception {
-        getMockSecrets();
+        loadMockSecrets();
         SecretManager sm = new SecretManager(mockAWSSecretClient,mockDao,mockKernelClient, localStoreMap);
         software.amazon.awssdk.aws.greengrass.model.GetSecretValueRequest request =
                 new software.amazon.awssdk.aws.greengrass.model.GetSecretValueRequest();
@@ -814,8 +814,8 @@ class SecretManagerTest {
         // Actually load the secrets
         when(mockAWSSecretClient.getSecret(any())).thenReturn(getMockSecretA()).thenReturn(getMockSecretB());
         List<AWSSecretResponse> storedSecrets = new ArrayList<>();
-        storedSecrets.add(getMockDaoSecretA());
-        storedSecrets.add(getMockDaoSecretB());
+        storedSecrets.add(loadMockDaoSecretA());
+        storedSecrets.add(loadMockDaoSecretB());
         when(mockDao.getAll()).thenReturn(SecretDocument.builder().secrets(storedSecrets).build());
         sm.syncFromCloud();
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
**Change 1:**
Currently, secret manager downloads all the secrets at once when the config changes. If configured secrets are downloaded incompletely due to an error (not network), secret manager is set to ERROR and thereby BROKEN state. This needs a new deployment to happen with updated config for secret manager to be up and running again. This is not desired.

PR changes: With this PR, if downloading secrets fail due to any reason, secret manager exception is not thrown. Instead we log and proceed and download those fail secrets only on need basis (with IPC request/or when the config changes). 

**Change 2:**
AWS Secret manager supports secret labels such that the labels are unique across different versions of a secret. 
Consider a local store contains a secret with two labels, label1 and label2 with other labels including (label1a, label1b) and (label2a, label2b) respectively. Currently, during a config update, if label1 download from cloud is successful and returns label2a and label2b as its updated labels and label2 download fails (falls back to secret in local store), local store will contain secrets label1 and label2 both with the same labels. This is an incorrect implementation as it returns incorrect secret values via IPC request is not consistent with cloud. 

Updating the secrets with proper version labels becomes even more important as we want to support downloading secrets via IPC and periodically. 

PR update: Created a separate class to read and update local secrets with proper labels/version stages. This is needed to properly update the secret labels/version stages when new secrets are downloaded. 

**Change 3**
When downloading a secret from cloud, we now check it is configured in the secret manager configuration. Otherwise, do nothing. 

**Change 4**
Move over security service and crypter related methods to this new `LocalStoreMap` class.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
