### PR TITLE
feat: add periodic refresh secret config

### DIFF
--- a/src/main/java/com/aws/greengrass/secretmanager/store/FileSecretStore.java
+++ b/src/main/java/com/aws/greengrass/secretmanager/store/FileSecretStore.java
@@ -53,7 +53,7 @@ public class FileSecretStore implements SecretStore<SecretDocument, AWSSecretRes
      * @return {@link SecretDocument} containing all persisted secrets
      * @throws SecretManagerException when there is any issue reading the store.
      */
-    public synchronized SecretDocument getAll() throws SecretManagerException {
+    public SecretDocument getAll() throws SecretManagerException {
         Topic secretResponseTopic = kernelClient.getConfig().lookup(SERVICES_NAMESPACE_TOPIC,
                     SecretManagerService.SECRET_MANAGER_SERVICE_NAME, RUNTIME_STORE_NAMESPACE_TOPIC,
                 SECRET_RESPONSE_TOPIC);
@@ -74,7 +74,7 @@ public class FileSecretStore implements SecretStore<SecretDocument, AWSSecretRes
      * @return {@link AWSSecretResponse} the secret given the arn and label, null if not present
      * @throws SecretManagerException when there is any issue reading the store.
      */
-    public synchronized AWSSecretResponse get(String secretArn, String label) throws SecretManagerException {
+    public AWSSecretResponse get(String secretArn, String label) throws SecretManagerException {
         if (Utils.isEmpty(secretArn) || Utils.isEmpty(label)) {
             throw new SecretManagerException("Cannot get secret response from store given empty arn or label");
         }
@@ -123,7 +123,7 @@ public class FileSecretStore implements SecretStore<SecretDocument, AWSSecretRes
      * @param doc {@link SecretDocument} containing list of secrets to persist
      * @throws SecretManagerException when there is any issue writing to the store.
      */
-    public synchronized void saveAll(SecretDocument doc) throws SecretManagerException {
+    public void saveAll(SecretDocument doc) throws SecretManagerException {
         Topic secretTopic = kernelClient.getConfig().lookup(SERVICES_NAMESPACE_TOPIC,
                 SecretManagerService.SECRET_MANAGER_SERVICE_NAME, RUNTIME_STORE_NAMESPACE_TOPIC,
                 SECRET_RESPONSE_TOPIC);

--- a/src/test/java/com/aws/greengrass/secretmanager/SecretManagerTest.java
+++ b/src/test/java/com/aws/greengrass/secretmanager/SecretManagerTest.java
@@ -53,6 +53,7 @@ import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 

--- a/src/test/resources/com/aws/greengrass/secretmanager/config_refresh.yaml
+++ b/src/test/resources/com/aws/greengrass/secretmanager/config_refresh.yaml
@@ -1,0 +1,34 @@
+---
+services:
+  main:
+    lifecycle:
+      install: echo "main"
+    dependencies:
+      - aws.greengrass.SecretManager
+      - ComponentRequestingSecrets
+      - ComponentWithNoAccessPolicy
+
+  aws.greengrass.SecretManager:
+    configuration:
+      cloudSecrets:
+        - arn: "arn:aws:secretsmanager:us-east-1:999936977227:secret:randomSecret-74lYJh"
+          labels:
+            - "new"
+      periodicRefreshIntervalMin: 0.05
+
+  ComponentRequestingSecrets:
+    dependencies:
+      - aws.greengrass.SecretManager
+    configuration:
+      accessControl:
+        aws.greengrass.SecretManager:
+          policyId1:secretPolicy:
+            policyDescription: access to pubsub topics for ServiceName
+            operations:
+              - 'aws.greengrass#GetSecretValue'
+            resources:
+              - '*'
+
+  ComponentWithNoAccessPolicy:
+    dependencies:
+      - aws.greengrass.SecretManager


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- Remove `synchronized`  and `ConcurrentHashMap` and use cycle detecting locks to properly updated the shared objects. 
- Introduce a new config variable called `periodicRefreshIntervalMin`with 0 as default value. Whenever secret manager config changes, secrets are synced from cloud. After that, secrets are refreshed at the configured interval.
- When  `periodicRefreshIntervalMin` is set to 0, secrets are never refreshed after the first sync. That way, the default behavior of the component still remains the same while making it configurable. 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
