### PR TITLE
refactor: run ipc async requests from a separate threadpool

### DIFF
--- a/src/main/java/com/aws/greengrass/secretmanager/SecretManagerIPCAgent.java
+++ b/src/main/java/com/aws/greengrass/secretmanager/SecretManagerIPCAgent.java
@@ -8,9 +8,11 @@ package com.aws.greengrass.secretmanager;
 import com.aws.greengrass.authorization.AuthorizationHandler;
 import com.aws.greengrass.authorization.Permission;
 import com.aws.greengrass.authorization.exceptions.AuthorizationException;
+import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.secretmanager.exception.v1.GetSecretException;
+import com.aws.greengrass.util.Coerce;
 import software.amazon.awssdk.aws.greengrass.GeneratedAbstractGetSecretValueOperationHandler;
 import software.amazon.awssdk.aws.greengrass.model.GetSecretValueRequest;
 import software.amazon.awssdk.aws.greengrass.model.GetSecretValueResponse;
@@ -21,8 +23,17 @@ import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext
 import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.inject.Inject;
 
+import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
+import static com.aws.greengrass.secretmanager.SecretManagerService.CLOUD_REQUEST_QUEUE_SIZE_TOPIC;
+import static com.aws.greengrass.secretmanager.SecretManagerService.PERFORMANCE_TOPIC;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.GET_SECRET_VALUE;
 
 /**
@@ -32,6 +43,13 @@ public class SecretManagerIPCAgent {
     private static final Logger logger = LogManager.getLogger(SecretManagerIPCAgent.class);
     private final SecretManager secretManager;
     private final AuthorizationHandler authorizationHandler;
+    private static final int DEFAULT_CLOUD_REQUEST_SIZE = 100;
+    //IPC requests that make cloud call are processed by a separate thread (main ipc event loop thread
+    // is not blocked by these requests). These requests are queued and processed as they come in.
+    private AtomicReference<ExecutorService> cloudCallThreadPool = new AtomicReference<>(null);
+    private static final int DEFAULT_CORE_POOL_SIZE = 1;
+    private static final int DEFAULT_MAX_POOL_SIZE = 1;
+    private static final int DEFAULT_KEEP_ALIVE_TIMEOUT_SECONDS = 60;
 
     /**
      * Constructor for secret manager ipc agent.
@@ -43,6 +61,28 @@ public class SecretManagerIPCAgent {
     public SecretManagerIPCAgent(SecretManager secretManager, AuthorizationHandler authorizationHandler) {
         this.secretManager = secretManager;
         this.authorizationHandler = authorizationHandler;
+    }
+
+    /**
+     * Use secret manager config to set the cloud call thread pool size. If not configured, default value is used.
+     *
+     * @param config component configuration
+     */
+    public void setCloudCallThreadPool(Topics config) {
+        int cloudCallQueueSize = Coerce.toInt(config.lookupTopics(CONFIGURATION_CONFIG_KEY, PERFORMANCE_TOPIC)
+                .findOrDefault(DEFAULT_CLOUD_REQUEST_SIZE, CLOUD_REQUEST_QUEUE_SIZE_TOPIC));
+        if (cloudCallQueueSize <= 0) {
+            logger.atWarn().kv("queueSize", DEFAULT_CLOUD_REQUEST_SIZE)
+                    .log("Using default value for cloud request queue size as the configured value is invalid");
+            cloudCallQueueSize = DEFAULT_CLOUD_REQUEST_SIZE;
+        }
+        ExecutorService oldThreadPool = cloudCallThreadPool.getAndSet(
+                new ThreadPoolExecutor(DEFAULT_CORE_POOL_SIZE, DEFAULT_MAX_POOL_SIZE,
+                        DEFAULT_KEEP_ALIVE_TIMEOUT_SECONDS, TimeUnit.SECONDS,
+                        new LinkedBlockingQueue<>(cloudCallQueueSize)));
+        if (oldThreadPool != null) {
+            oldThreadPool.shutdownNow();
+        }
     }
 
     public GetSecretValueOperationHandler getSecretValueOperationHandler(OperationContinuationHandlerContext context) {
@@ -75,7 +115,7 @@ public class SecretManagerIPCAgent {
 
         @Override
         public GetSecretValueResponse handleRequest(GetSecretValueRequest request) {
-            logger.atDebug("ipc-get-secret-request").log();
+            logger.atDebug().log("ipc-get-secret-request");
             try {
                 logger.atInfo().event("secret-access").kv("Principal", serviceName).kv("secret", request.getSecretId())
                         .log("requested secret");
@@ -98,8 +138,20 @@ public class SecretManagerIPCAgent {
 
         @Override
         public CompletableFuture<GetSecretValueResponse> handleRequestAsync(GetSecretValueRequest request) {
-            // TODO: Limit the no of simultaneous requests using a separate threadpool with configurable size
-            return CompletableFuture.supplyAsync(() -> handleRequest(request));
+            // This should never be used
+            cloudCallThreadPool.compareAndSet(null,
+                    new ThreadPoolExecutor(DEFAULT_CORE_POOL_SIZE, DEFAULT_MAX_POOL_SIZE,
+                            DEFAULT_KEEP_ALIVE_TIMEOUT_SECONDS, TimeUnit.SECONDS,
+                            new LinkedBlockingQueue<>(DEFAULT_CLOUD_REQUEST_SIZE)));
+            try {
+                return CompletableFuture.supplyAsync(() -> handleRequest(request), cloudCallThreadPool.get());
+            } catch (RejectedExecutionException e) {
+                CompletableFuture<GetSecretValueResponse> fut = new CompletableFuture<>();
+                logger.atWarn().kv("componentName", serviceName)
+                        .log("Unable to queue GetSecretValueResponse. {}", e.getMessage());
+                fut.completeExceptionally(new ServiceError("Unable to queue request"));
+                return fut;
+            }
         }
 
         @Override

--- a/src/test/java/com/aws/greengrass/secretmanager/SecretManagerServiceTest.java
+++ b/src/test/java/com/aws/greengrass/secretmanager/SecretManagerServiceTest.java
@@ -80,7 +80,7 @@ public class SecretManagerServiceTest {
     void startKernelWithConfig(String configFile, State expectedState) throws InterruptedException {
         CountDownLatch secretManagerRunning = new CountDownLatch(1);
         CountDownLatch cdl = new CountDownLatch(1);
-        doAnswer((i)->{
+        doAnswer((i) -> {
             cdl.countDown();
             return null;
         }).when(mockSecretManager).syncFromCloud();
@@ -125,7 +125,8 @@ public class SecretManagerServiceTest {
     }
 
     @Test
-    void GIVEN_secret_service_WHEN_load_secret_fails_with_crypto_error_THEN_service_reloads_secrets(ExtensionContext context) throws Exception {
+    void GIVEN_secret_service_WHEN_load_secret_fails_with_crypto_error_THEN_service_reloads_secrets(
+            ExtensionContext context) throws Exception {
         ignoreExceptionOfType(context, SecretManagerException.class);
 
         SecretManagerException ex = new SecretManagerException(new SecretCryptoException("Bad"));
@@ -151,11 +152,12 @@ public class SecretManagerServiceTest {
                         .versionStages(Arrays.asList(new String[]{CURRENT_LABEL, VERSION_LABEL}))
                         .createdDate(currentTime).build();
 
-        when(mockSecretManager.getSecret(any(com.aws.greengrass.secretmanager.model.v1.GetSecretValueRequest.class)))
-                .thenReturn(expectedResponse);
+        when(mockSecretManager.getSecret(
+                any(com.aws.greengrass.secretmanager.model.v1.GetSecretValueRequest.class))).thenReturn(
+                expectedResponse);
         when(mockSecretManager.validateSecretId(SECRET_ID)).thenReturn(SECRET_ID);
-        when(mockAuthorizationHandler.isAuthorized(stringCaptor.capture(), permissionCaptor.capture()))
-                .thenReturn(true);
+        when(mockAuthorizationHandler.isAuthorized(stringCaptor.capture(), permissionCaptor.capture())).thenReturn(
+                true);
 
         String requestString = String.format("{\"SecretId\": \"%s\", \"VersionId\": \"%s\"}", SECRET_ID, VERSION_ID);
         byte[] getSecretResponse =
@@ -175,9 +177,8 @@ public class SecretManagerServiceTest {
         assertEquals(GET_SECRET_VALUE, permissionCaptor.getValue().getOperation());
         assertEquals(serviceName, permissionCaptor.getValue().getPrincipal());
         assertEquals(SECRET_ID, permissionCaptor.getValue().getResource());
-        verify(mockAuthorizationHandler, atLeastOnce())
-                .registerComponent(SecretManagerService.SECRET_MANAGER_SERVICE_NAME,
-                        new HashSet<>(Arrays.asList(GET_SECRET_VALUE)));
+        verify(mockAuthorizationHandler, atLeastOnce()).registerComponent(
+                SecretManagerService.SECRET_MANAGER_SERVICE_NAME, new HashSet<>(Arrays.asList(GET_SECRET_VALUE)));
 
         // Now request with secret name that maps to the arn
         when(mockSecretManager.validateSecretId(SECRET_NAME)).thenReturn(SECRET_ID);
@@ -196,6 +197,7 @@ public class SecretManagerServiceTest {
             throws IOException {
         return OBJECT_MAPPER.readValue(bytes, com.aws.greengrass.secretmanager.model.v1.GetSecretValueError.class);
     }
+
     @Test
     void GIVEN_secret_service_WHEN_v1_get_called_and_errors_THEN_correct_response_returned(ExtensionContext context)
             throws Exception {
@@ -203,16 +205,17 @@ public class SecretManagerServiceTest {
         startKernelWithConfig("config.yaml", State.RUNNING);
         final String serviceName = "mockService";
 
-        when(mockSecretManager.getSecret(any(com.aws.greengrass.secretmanager.model.v1.GetSecretValueRequest.class)))
-                .thenThrow(new GetSecretException(400, "getSecret Error"));
+        when(mockSecretManager.getSecret(
+                any(com.aws.greengrass.secretmanager.model.v1.GetSecretValueRequest.class))).thenThrow(
+                new GetSecretException(400, "getSecret Error"));
         when(mockAuthorizationHandler.isAuthorized(any(), any())).thenReturn(true);
 
         com.aws.greengrass.secretmanager.model.v1.GetSecretValueRequest request =
                 com.aws.greengrass.secretmanager.model.v1.GetSecretValueRequest.builder().secretId(SECRET_ID)
                         .versionId(VERSION_ID).build();
         byte[] byteRequest = OBJECT_MAPPER.writeValueAsBytes(request);
-        byte[] getSecretResponse = kernel.getContext().get(SecretManagerService.class).getSecret(serviceName,
-                byteRequest);
+        byte[] getSecretResponse =
+                kernel.getContext().get(SecretManagerService.class).getSecret(serviceName, byteRequest);
 
         com.aws.greengrass.secretmanager.model.v1.GetSecretValueError parsedResponse = convertError(getSecretResponse);
         assertEquals(400, parsedResponse.getStatus());
@@ -228,8 +231,7 @@ public class SecretManagerServiceTest {
         assertEquals("Unable to parse request", parsedResponse.getMessage());
 
         // now let the auth fail
-        when(mockAuthorizationHandler.isAuthorized(any(), any())).
-                thenThrow(new AuthorizationException("Auth error"));
+        when(mockAuthorizationHandler.isAuthorized(any(), any())).thenThrow(new AuthorizationException("Auth error"));
         getSecretResponse = kernel.getContext().get(SecretManagerService.class).getSecret(serviceName, byteRequest);
         parsedResponse = convertError(getSecretResponse);
 
@@ -239,8 +241,9 @@ public class SecretManagerServiceTest {
         //Case for generic errors
         reset(mockAuthorizationHandler);
         when(mockAuthorizationHandler.isAuthorized(any(), any())).thenReturn(true);
-        when(mockSecretManager.getSecret(any(com.aws.greengrass.secretmanager.model.v1.GetSecretValueRequest.class)))
-                .thenThrow(new RuntimeException("Generic Error"));
+        when(mockSecretManager.getSecret(
+                any(com.aws.greengrass.secretmanager.model.v1.GetSecretValueRequest.class))).thenThrow(
+                new RuntimeException("Generic Error"));
         getSecretResponse = kernel.getContext().get(SecretManagerService.class).getSecret(serviceName, byteRequest);
         parsedResponse = convertError(getSecretResponse);
 
@@ -268,10 +271,9 @@ public class SecretManagerServiceTest {
                 com.aws.greengrass.secretmanager.model.v1.GetSecretValueRequest.builder().secretId(SECRET_ID)
                         .versionId(VERSION_ID).build();
         byte[] byteRequest = OBJECT_MAPPER.writeValueAsBytes(request);
-        byte[] getSecretResponse = kernel.getContext().get(SecretManagerService.class).getSecret(serviceName,
-                byteRequest);
-        com.aws.greengrass.secretmanager.model.v1.GetSecretValueError actualResponse =
-                convertError(getSecretResponse);
+        byte[] getSecretResponse =
+                kernel.getContext().get(SecretManagerService.class).getSecret(serviceName, byteRequest);
+        com.aws.greengrass.secretmanager.model.v1.GetSecretValueError actualResponse = convertError(getSecretResponse);
 
         assertEquals(403, actualResponse.getStatus());
 
@@ -279,8 +281,8 @@ public class SecretManagerServiceTest {
         reset(mockAuthorizationHandler);
         when(mockAuthorizationHandler.isAuthorized(any(), any())).thenReturn(true);
         GetSecretException exception = new GetSecretException(400, "test");
-        when(mockSecretManager.getSecret(any(com.aws.greengrass.secretmanager.model.v1.GetSecretValueRequest.class)))
-                .thenThrow(exception);
+        when(mockSecretManager.getSecret(
+                any(com.aws.greengrass.secretmanager.model.v1.GetSecretValueRequest.class))).thenThrow(exception);
         getSecretResponse = kernel.getContext().get(SecretManagerService.class).getSecret(serviceName, byteRequest);
 
         actualResponse = convertError(getSecretResponse);

--- a/src/test/java/com/aws/greengrass/secretmanager/SecretManagerTest.java
+++ b/src/test/java/com/aws/greengrass/secretmanager/SecretManagerTest.java
@@ -58,6 +58,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
+import static com.aws.greengrass.secretmanager.SecretManagerService.CLOUD_REQUEST_QUEUE_SIZE_TOPIC;
+import static com.aws.greengrass.secretmanager.SecretManagerService.PERFORMANCE_TOPIC;
 import static com.aws.greengrass.secretmanager.SecretManagerService.SECRETS_TOPIC;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static org.hamcrest.MatcherAssert.assertThat;


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**
- Use a separate threadpool to handle the ipc requests that make a cloud call. This is to ensure that the main ipc event loop thread (which is used for all other components ipc operations) is not blocked by those ipc requests that take longer time. 

- Only one thread from a pool handles all such requests in the order of their arrival.  There's no limit on the number of requests that are queued. 

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
