### PR TITLE
refactor: remove depedency on lock factory

### DIFF
--- a/src/main/java/com/aws/greengrass/secretmanager/SecretManagerIPCAgent.java
+++ b/src/main/java/com/aws/greengrass/secretmanager/SecretManagerIPCAgent.java
@@ -73,6 +73,7 @@ public class SecretManagerIPCAgent {
                 .findOrDefault(DEFAULT_CLOUD_REQUEST_SIZE, CLOUD_REQUEST_QUEUE_SIZE_TOPIC));
         if (cloudCallQueueSize <= 0) {
             logger.atWarn().kv("queueSize", DEFAULT_CLOUD_REQUEST_SIZE)
+                    .kv("configured", cloudCallQueueSize)
                     .log("Using default value for cloud request queue size as the configured value is invalid");
             cloudCallQueueSize = DEFAULT_CLOUD_REQUEST_SIZE;
         }

--- a/src/main/java/com/aws/greengrass/secretmanager/SecretManagerService.java
+++ b/src/main/java/com/aws/greengrass/secretmanager/SecretManagerService.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -132,6 +131,18 @@ public class SecretManagerService extends PluginService {
                 }, 0, refreshIntervalSeconds, TimeUnit.SECONDS);
             }
         }
+    }
+
+    @Override
+    protected void shutdown() {
+        logger.atDebug().log("Shutting down secrets manager");
+        synchronized (scheduleSyncFutureLockObject) {
+            if (scheduledSyncFuture != null) {
+                scheduledSyncFuture.cancel(true);
+                scheduledSyncFuture = null;
+            }
+        }
+        logger.atDebug().log("Done shutting down secrets manager");
     }
 
     @Override

--- a/src/main/java/com/aws/greengrass/secretmanager/SecretManagerService.java
+++ b/src/main/java/com/aws/greengrass/secretmanager/SecretManagerService.java
@@ -19,13 +19,11 @@ import com.aws.greengrass.secretmanager.exception.v1.GetSecretException;
 import com.aws.greengrass.secretmanager.model.v1.GetSecretValueError;
 import com.aws.greengrass.secretmanager.model.v1.GetSecretValueResult;
 import com.aws.greengrass.util.Coerce;
-import com.aws.greengrass.util.LockScope;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Setter;
 import software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService;
-import vendored.com.google.common.util.concurrent.CycleDetectingLockFactory;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -35,12 +33,10 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.Lock;
 import javax.inject.Inject;
 
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.GET_SECRET_VALUE;
-import static vendored.com.google.common.util.concurrent.CycleDetectingLockFactory.Policies.THROW;
 
 @ImplementsService(name = SecretManagerService.SECRET_MANAGER_SERVICE_NAME)
 public class SecretManagerService extends PluginService {
@@ -55,10 +51,8 @@ public class SecretManagerService extends PluginService {
 
     private final SecretManager secretManager;
     private final AuthorizationHandler authorizationHandler;
-    private final ExecutorService executor;
     private ScheduledFuture<?> scheduledSyncFuture = null;
-    private final Lock scheduleSyncFutureLock =
-            CycleDetectingLockFactory.newInstance(THROW).newReentrantLock("scheduleSyncFutureLock");
+    private final Object scheduleSyncFutureLockObject = new Object();
     private final ScheduledExecutorService ses;
     private final ChildChanged handleConfigurationChangeLambda = (whatHappened, node) -> {
         if (whatHappened == WhatHappened.timestampUpdated || whatHappened == WhatHappened.interiorAdded) {
@@ -87,16 +81,14 @@ public class SecretManagerService extends PluginService {
      * @param topics               root Configuration topic for this service
      * @param secretManager        secret manager which manages secrets
      * @param authorizationHandler authorization handler
-     * @param executorService executor service
      * @param ses scheduled executor service
      */
     @Inject
     public SecretManagerService(Topics topics, SecretManager secretManager, AuthorizationHandler authorizationHandler,
-                                ExecutorService executorService, ScheduledExecutorService ses) {
+                                ScheduledExecutorService ses) {
         super(topics);
         this.secretManager = secretManager;
         this.authorizationHandler = authorizationHandler;
-        this.executor = executorService;
         this.ses = ses;
     }
 
@@ -112,7 +104,7 @@ public class SecretManagerService extends PluginService {
     }
 
     private void serviceChanged() {
-        try (LockScope ls = LockScope.lock(scheduleSyncFutureLock)) {
+        synchronized (scheduleSyncFutureLockObject) {
             if (scheduledSyncFuture != null) {
                 scheduledSyncFuture.cancel(false);
                 scheduledSyncFuture = null;


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
PR for removing dependency on cycle detection (that was introduced in nucleus 2.11.0) in Secret manager. This will let secret manager have dependency on nucleus >=2.5.0

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
