### PR TITLE
fix: store secrets on disk when partial arn is used

### DIFF
--- a/src/main/java/com/aws/greengrass/secretmanager/LocalStoreMap.java
+++ b/src/main/java/com/aws/greengrass/secretmanager/LocalStoreMap.java
@@ -116,9 +116,9 @@ public class LocalStoreMap {
                 secretConfiguration.forEach((secretConfig) -> {
                     secretConfig.getLabels().forEach((label) -> {
                         String arn = secretConfig.getArn();
-                        if (secrets.containsKey(arn) && secrets.get(arn).responseMap.containsKey(label)) {
-                            responses.add(secrets.get(arn).responseMap.get(label));
-                        }
+                        secrets.entrySet().stream().filter(entry -> entry.getKey().contains(arn))
+                                .filter(entry -> entry.getValue().responseMap.containsKey(label))
+                                .forEach(entry -> responses.add(entry.getValue().responseMap.get(label)));
                     });
                 });
             }

--- a/src/test/resources/com/aws/greengrass/secretmanager/config.yaml
+++ b/src/test/resources/com/aws/greengrass/secretmanager/config.yaml
@@ -15,7 +15,7 @@ services:
         - arn: "arn:aws:secretsmanager:us-east-1:999936977227:secret:randomSecret-74lYJh"
           labels:
             - "new"
-
+        - arn: "arn:aws:secretsmanager:us-east-1:999936977227:secret:partialarn"
   ComponentRequestingSecrets:
     dependencies:
       - aws.greengrass.SecretManager


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
In 2.2.0 and 2.2.1 of secret manager, downloaded secret arns are compared with the exact `arn` provided in the component configuration before writing them to the disk. This breaks the support for partial arn because the downloaded secret arn is complete and doesn't match the partial arn from config. 

This fix checks if the downloaded secret arn contains the arn from the config instead of checking for exact match.

**Why is this change necessary:**
Fix the bug introduced in 2.2.0 and 2.2.1 versions of secrets manager. 

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
