### PR TITLE
fix: persist local store secrets

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -45,13 +45,13 @@ jobs:
         shell: cmd
         if: matrix.os == 'windows-latest'
       - name: Upload Failed Test Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: Failed Test Report
           path: target/surefire-reports
       - name: Upload Coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: matrix.os == 'ubuntu-latest'
         with:
           name: Coverage Report ${{ matrix.os }}

--- a/src/main/java/com/aws/greengrass/secretmanager/LocalStoreMap.java
+++ b/src/main/java/com/aws/greengrass/secretmanager/LocalStoreMap.java
@@ -281,13 +281,6 @@ public class LocalStoreMap {
                 return;
             }
             for (AWSSecretResponse secretResponse : doc.getSecrets()) {
-                try {
-                    decrypt(secretResponse);
-                } catch (SecretCryptoException e) {
-                    logger.atWarn().kv("secretArn", secretResponse.getArn()).kv("label", secretResponse.getVersionId())
-                            .log("Unable to decrypt the secret in local store.");
-                    continue;
-                }
                 secrets.putIfAbsent(secretResponse.getArn(), new Labels(new HashMap<>()));
                 secretResponse.getVersionStages().forEach((label) -> {
                     secrets.get(secretResponse.getArn()).responseMap.put(label, secretResponse);

--- a/src/main/java/com/aws/greengrass/secretmanager/store/FileSecretStore.java
+++ b/src/main/java/com/aws/greengrass/secretmanager/store/FileSecretStore.java
@@ -15,13 +15,10 @@ import com.aws.greengrass.secretmanager.model.AWSSecretResponse;
 import com.aws.greengrass.secretmanager.model.SecretDocument;
 import com.aws.greengrass.util.Coerce;
 import com.aws.greengrass.util.Utils;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
-import java.util.Iterator;
-import java.util.List;
 import javax.inject.Inject;
 
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.RUNTIME_STORE_NAMESPACE_TOPIC;

--- a/src/test/java/com/aws/greengrass/secretmanager/SecretManagerTest.java
+++ b/src/test/java/com/aws/greengrass/secretmanager/SecretManagerTest.java
@@ -778,6 +778,7 @@ class SecretManagerTest {
     void GIVEN_secret_manager_WHEN_get_called_with_invalid_request_THEN_proper_errors_are_returned() throws Exception {
         loadMockSecrets();
         SecretManager sm = new SecretManager(mockAWSSecretClient,mockDao,mockKernelClient, localStoreMap);
+        when(mockDao.getAll()).thenReturn(SecretDocument.builder().secrets(new ArrayList<>()).build());
         software.amazon.awssdk.aws.greengrass.model.GetSecretValueRequest request =
                 new software.amazon.awssdk.aws.greengrass.model.GetSecretValueRequest();
         try {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Change 1: Do not check if the existing secrets in the local store are decryptable. This check was originally added to filter out the secrets from the local store that are not decryptable because the secrets are corrupted or the device key is changed (this check is also covered when the cache is reloaded). However, in some cases, we cannot decrypt the secrets simply because the security service is not available. In this case, removing the existing secrets from local store it not correct. 

Change 2:
When loading the local store secrets (encrypted) into cache (decrypted), if the secret is not decryptable, it is not loaded into the cache. So, if the security service is not up when loading secrets into cache, we cannot decrypt the secrets and hence the cache remains empty. 
When the secret is requested via IPC, we rely on cache to validate the secret Id. So, if it is not in cache, we throw an exception. However,  when the security service becomes available, we should decrypt and update the cache and validate the secret id against the updated cache. 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
