### PR TITLE
fix: refresh secret from if it doesn't exist in cache

### DIFF
--- a/src/main/java/com/aws/greengrass/secretmanager/SecretManager.java
+++ b/src/main/java/com/aws/greengrass/secretmanager/SecretManager.java
@@ -36,6 +36,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.regex.Pattern;
 import javax.inject.Inject;
 
@@ -54,6 +55,7 @@ public class SecretManager {
             "arn:([^:]+):secretsmanager:[a-z0-9\\-]+:[0-9]{12}:secret:([a-zA-Z0-9\\\\]+/)*"
                     + "[a-zA-Z0-9/_+=,.@\\-]+(-[a-zA-Z0-9]+)?";
     private static final String secretNotFoundErr = "Secret not found ";
+    private static final String secretNotConfiguredErr = "Secret not configured ";
     private static final String IPC_REQUEST_REFRESH_FIELD = "refresh";
     private final Logger logger = LogManager.getLogger(SecretManager.class);
     // Cache which holds aws secrets result
@@ -137,7 +139,7 @@ public class SecretManager {
 
             for (SecretConfiguration configuredSecret : secretConfiguration) {
                 String arn = configuredSecret.getArn();
-                if (!Pattern.matches(VALID_SECRET_ARN_PATTERN, arn)) {
+                if (!isSecretIdArn(arn)) {
                     logger.atWarn().kv("Secret ", arn).log("Skipping invalid secret arn configured");
                     continue;
                 }
@@ -183,7 +185,7 @@ public class SecretManager {
     */
     private void loadCache(AWSSecretResponse awsSecretResponse) {
         synchronized (cacheLockObject) {
-            GetSecretValueResponse decryptedResponse = null;
+            GetSecretValueResponse decryptedResponse;
             try {
                 decryptedResponse = localStoreMap.decrypt(awsSecretResponse);
             } catch (SecretCryptoException e) {
@@ -206,7 +208,7 @@ public class SecretManager {
         String versionLabel = Utils.isEmpty(versionStage) ? LATEST_LABEL : versionStage;
         List<SecretConfiguration> configurations = getSecretConfiguration();
         boolean isSecretLabelConfigured = configurations.stream().anyMatch(
-                (secret) -> arn.contains(secret.getArn()) && secret.getLabels().contains(versionStage));
+                (secret) -> secret.getArn().contains(arn) && secret.getLabels().contains(versionStage));
         // If the requested secret is not  configured, then do not download.
         if (!isSecretLabelConfigured) {
             logger.atWarn().kv("secret", arn).kv("versionStage", versionStage).log("Not downloading the secret from "
@@ -231,7 +233,7 @@ public class SecretManager {
     private GetSecretValueResponse getSecretFromCache(String secretId, String arn, String versionId,
                                                       String versionStage) throws GetSecretException {
         if (!Utils.isEmpty(versionId)) {
-            if (!cache.containsKey(arn + versionId)) {
+            if (!isSecretPresentInCache(arn + versionId)) {
                 String errorStr = "Version Id " + versionId + " not found for secret " + secretId;
                 logger.atError().kv("secretId", secretId).log(errorStr);
                 throw new GetSecretException(404, errorStr);
@@ -240,7 +242,7 @@ public class SecretManager {
         }
 
         if (!Utils.isEmpty(versionStage)) {
-            if (!cache.containsKey(arn + versionStage)) {
+            if (!isSecretPresentInCache(arn + versionStage)) {
                 String errorStr = "Version stage " + versionStage + " not found for secret " + secretId;
                 logger.atError().kv("secretId", secretId).log(errorStr);
                 throw new GetSecretException(404, errorStr);
@@ -248,7 +250,7 @@ public class SecretManager {
             return cache.get(arn + versionStage);
         }
         // If none of the label and version are specified then return LATEST_LABEL
-        if (!cache.containsKey((arn + LATEST_LABEL))) {
+        if (!isSecretPresentInCache((arn + LATEST_LABEL))) {
             logger.atError().kv("secretId", secretId).log(secretNotFoundErr);
             throw new GetSecretException(404, secretNotFoundErr + secretId);
         }
@@ -266,14 +268,15 @@ public class SecretManager {
                     .log("Both secret version and id are set");
             throw new GetSecretException(400, "Both versionId and Stage are set in the request");
         }
+
         /*
-         If refresh is set to true, try fetching the secret from cloud. This will update the local store and cache as
-          well. Refresh secrets by label only. If refreshing the secret fails for any reason, we fall back to local
-          store.
+        If refresh is set to true, try fetching the secret from cloud. This will update the local store and cache as
+        well. Refresh secrets by label only. If refreshing the secret fails for any reason, we fall back to local
+        store.
          */
         String arn =  secretId;
         try {
-             arn = validateSecretId(secretId);
+            arn = validateSecretId(secretId);
             if (refreshSecret && Utils.isEmpty(versionId)) {
                 refreshSecretFromCloud(arn, versionStage);
             }
@@ -325,6 +328,10 @@ public class SecretManager {
             return translateModeltoIpc(secretResponse);
     }
 
+    private boolean isSecretPresentInCache(String arn) {
+        return cache.containsKey(arn);
+    }
+
     /**
      * Return secret arn given secretId. If secret name is provided, then return its mapped arn.
      *
@@ -336,26 +343,49 @@ public class SecretManager {
         if (Utils.isEmpty(secretId)) {
             throw new GetSecretException(400, "SecretId absent in the request");
         }
-        try {
-            return getArnFromCache(secretId);
-        } catch (GetSecretException e) {
+        String arn = getArnFromCache(secretId);
+        if (!isSecretPresentInCache(arn)) {
             try {
                 reloadCache();
-                return getArnFromCache(secretId); // throw GetSecretException if the secret doesn't exist
-            } catch (SecretManagerException ex) {
-                throw new GetSecretException(404, secretNotFoundErr + secretId);
+            } catch (SecretManagerException e) {
+                // TODO: Improve return code where device is offline and SM is unable to load cache from disk
+                logger.atWarn().setCause(e).log("Unable to load secrets from cache");
             }
         }
+        return arn;
     }
 
-    private String getArnFromCache(String secretId) throws GetSecretException {
+    private boolean isSecretIdArn(final String secretId) {
+        return Pattern.matches(VALID_SECRET_ARN_PATTERN, secretId);
+    }
+
+    private boolean doesSecretNameMatchWithConfiguredArn(String secretName, String secretArn) {
+        String regex = ".*:secret:" + Pattern.quote(secretName) + "-[A-Za-z0-9]{6}(?::[A-Za-z0-9/_+=.@-]+)?$";
+        Pattern pattern = Pattern.compile(regex);
+        return pattern.matcher(secretArn).matches();
+    }
+
+    // TODO: add validation for labels
+    private String getArnFromCache(final String secretId) throws GetSecretException {
         String arn = secretId;
-        boolean isNotAnArn = !Pattern.matches(VALID_SECRET_ARN_PATTERN, secretId);
-        if (isNotAnArn) {
+        if (!isSecretIdArn(secretId)) {
             arn = nameToArnMap.get(secretId);
         }
-        if (Utils.isEmpty(arn) || !cache.containsKey(arn)) {
-            throw new GetSecretException(404, secretNotFoundErr + secretId);
+
+        /*
+        In case device was offline or security service was unavailable during the initial sync, nameToArnMap
+        is empty and if GetSecret IPC is invoked using a secret name with refresh, we fail.
+        Fix: try to lookup the secret ARN using the requested secret name in configured secrets.
+         */
+        if (Utils.isEmpty(arn)) {
+            List<SecretConfiguration> configurations = getSecretConfiguration();
+            Optional<SecretConfiguration> matchedSecretConfig = configurations.stream()
+                    .filter(config -> doesSecretNameMatchWithConfiguredArn(secretId, config.getArn()))
+                    .findFirst();
+            if (matchedSecretConfig.isPresent()) {
+                return matchedSecretConfig.get().getArn();
+            }
+            throw new GetSecretException(404, secretNotConfiguredErr + secretId);
         }
         return arn;
     }

--- a/src/main/java/com/aws/greengrass/secretmanager/SecretManagerService.java
+++ b/src/main/java/com/aws/greengrass/secretmanager/SecretManagerService.java
@@ -201,20 +201,16 @@ public class SecretManagerService extends PluginService {
                 .log("requested secret");
 
         int status;
-        String message = null;
+        String message;
 
         try {
             com.aws.greengrass.secretmanager.model.v1.GetSecretValueRequest getSecretValueRequest =
                     OBJECT_MAPPER.readValue(request,
                             com.aws.greengrass.secretmanager.model.v1.GetSecretValueRequest.class);
-            boolean isSecretValidated = secretManagerIPCAgent.validateSecretIdAndDoAuthorization(GET_SECRET_VALUE,
+            secretManagerIPCAgent.validateSecretIdAndDoAuthorization(GET_SECRET_VALUE,
                     serviceName,
                     getSecretValueRequest.getSecretId());
             GetSecretValueResult response = secretManager.getSecret(getSecretValueRequest);
-            if (!isSecretValidated) {
-                secretManagerIPCAgent.validateSecretIdAndDoAuthorization(GET_SECRET_VALUE, serviceName,
-                        response.getArn());
-            }
             try {
                 return OBJECT_MAPPER.writeValueAsBytes(response);
             } catch (JsonProcessingException e) {

--- a/src/main/java/com/aws/greengrass/secretmanager/SecretManagerService.java
+++ b/src/main/java/com/aws/greengrass/secretmanager/SecretManagerService.java
@@ -207,10 +207,14 @@ public class SecretManagerService extends PluginService {
             com.aws.greengrass.secretmanager.model.v1.GetSecretValueRequest getSecretValueRequest =
                     OBJECT_MAPPER.readValue(request,
                             com.aws.greengrass.secretmanager.model.v1.GetSecretValueRequest.class);
-            secretManagerIPCAgent.validateSecretIdAndDoAuthorization(GET_SECRET_VALUE, serviceName,
+            boolean isSecretValidated = secretManagerIPCAgent.validateSecretIdAndDoAuthorization(GET_SECRET_VALUE,
+                    serviceName,
                     getSecretValueRequest.getSecretId());
             GetSecretValueResult response = secretManager.getSecret(getSecretValueRequest);
-
+            if (!isSecretValidated) {
+                secretManagerIPCAgent.validateSecretIdAndDoAuthorization(GET_SECRET_VALUE, serviceName,
+                        response.getArn());
+            }
             try {
                 return OBJECT_MAPPER.writeValueAsBytes(response);
             } catch (JsonProcessingException e) {

--- a/src/test/java/com/aws/greengrass/secretmanager/SecretManagerServiceIntegTest.java
+++ b/src/test/java/com/aws/greengrass/secretmanager/SecretManagerServiceIntegTest.java
@@ -473,6 +473,6 @@ public class SecretManagerServiceIntegTest extends BaseITCase {
         GreengrassCoreIPCClientV2 clientV2 = IPCTestUtils.connectV2Client(kernel, "ComponentRequestingSecrets");
         ResourceNotFoundError err = assertThrows(ResourceNotFoundError.class,
                 () -> clientV2.getSecretValue(secretNotConfiguredReq));
-        assertThat(err.getMessage(), containsString("Secret not found secretNotConfigured"));
+        assertThat(err.getMessage(), containsString("Secret not configured secretNotConfigured"));
     }
 }

--- a/src/test/java/com/aws/greengrass/secretmanager/SecretManagerServiceTest.java
+++ b/src/test/java/com/aws/greengrass/secretmanager/SecretManagerServiceTest.java
@@ -251,6 +251,7 @@ public class SecretManagerServiceTest {
         assertEquals("Generic Error", parsedResponse.getMessage());
 
         // Now invalid secretId
+        reset(mockSecretManager);
         when(mockSecretManager.validateSecretId(SECRET_ID)).thenThrow(new GetSecretException(400, "getSecret Error"));
         getSecretResponse = kernel.getContext().get(SecretManagerService.class).getSecret(serviceName, byteRequest);
         parsedResponse = convertError(getSecretResponse);

--- a/src/test/java/com/aws/greengrass/secretmanager/SecretManagerTest.java
+++ b/src/test/java/com/aws/greengrass/secretmanager/SecretManagerTest.java
@@ -346,7 +346,6 @@ class SecretManagerTest {
         request.setSecretId(SECRET_NAME_1);
         request.setRefresh(true);
 
-        when(mockAWSSecretClient.getSecret(any())).thenThrow(SecretManagerException.class);
         software.amazon.awssdk.aws.greengrass.model.GetSecretValueResponse response = sm.getSecret(request);
 
         assertArrayEquals(SECRET_VALUE_BINARY_1, response.getSecretValue().getSecretBinary());

--- a/src/test/java/com/aws/greengrass/secretmanager/SecretManagerTest.java
+++ b/src/test/java/com/aws/greengrass/secretmanager/SecretManagerTest.java
@@ -63,6 +63,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
@@ -845,6 +846,45 @@ class SecretManagerTest {
             assertEquals(404, response.getStatus());
             assertEquals("Version stage " + invalidLabel + " not found for secret " + SECRET_NAME_1,
                     response.getMessage());
+        }
+    }
+
+    @Test
+    void GIVEN_secret_manager_WHEN_validate_secret_with_friendly_name_THEN_proper_results_are_returned() throws Exception {
+        // GIVEN
+        loadMockSecrets();
+        String mockArn = "arn:aws:secretsmanager:us-east-1:999936977227:secret:Secret3-74lYJh";
+        when(mockDao.getAll()).thenReturn(SecretDocument.builder().secrets(new ArrayList<>(
+                Collections.singletonList(AWSSecretResponse.builder().name("Secret3")
+                        .arn(mockArn).versionId("mock-version-id")
+                        .versionStages(new ArrayList<>(Collections.singletonList("mock-version-stage"))).build())
+        )).build());
+        SecretManager sm = new SecretManager(mockAWSSecretClient, mockDao, mockKernelClient, localStoreMap);
+        String arn1 = sm.validateSecretId("Secret1");
+        assertEquals(arn1, ARN_1);
+
+        String arn2 = sm.validateSecretId(PARTIAL_ARN);
+        assertEquals(arn2, PARTIAL_ARN);
+
+        try {
+            sm.validateSecretId("Secret1-74lYJh");
+        } catch (Exception e) {
+            assertTrue(e instanceof GetSecretException);
+            GetSecretException getSecretException = (GetSecretException) e;
+            assertEquals(getSecretException.getStatus(), 404);
+            assertEquals(getSecretException.getMessage(), "Secret not configured Secret1-74lYJh");
+        }
+
+        String arn3 = sm.validateSecretId("Secret3");
+        assertEquals(arn3, mockArn);
+
+        try {
+            sm.validateSecretId("Secret4");
+        } catch (Exception e) {
+            assertTrue(e instanceof GetSecretException);
+            GetSecretException getSecretException = (GetSecretException) e;
+            assertEquals(getSecretException.getStatus(), 404);
+            assertEquals(getSecretException.getMessage(), "Secret not configured Secret4");
         }
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
A secret is not present in the cache if it was not downloaded (and encrypted) successfully. When an IPC request to get secret is made, a secret is validated in the cache. If is not present, we throw an exception before trying to fetch it from the cloud. 

With this change, we refresh from cloud if an exception during secret validation.  
 
**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
