### PR TITLE
fix: empty version check

### DIFF
--- a/src/main/java/com/aws/greengrass/secretmanager/SecretManager.java
+++ b/src/main/java/com/aws/greengrass/secretmanager/SecretManager.java
@@ -210,7 +210,7 @@ public class SecretManager {
         boolean isSecretLabelConfigured = configurations.stream().anyMatch(
                 (secret) -> secret.getArn().contains(arn) && secret.getLabels().contains(versionStage));
         // If the requested secret is not  configured, then do not download.
-        if (!isSecretLabelConfigured) {
+        if (!Utils.isEmpty(versionStage) && !isSecretLabelConfigured) {
             logger.atWarn().kv("secret", arn).kv("versionStage", versionStage).log("Not downloading the secret from "
                     + "cloud as it is not configured.");
             return;
@@ -274,9 +274,8 @@ public class SecretManager {
         well. Refresh secrets by label only. If refreshing the secret fails for any reason, we fall back to local
         store.
          */
-        String arn =  secretId;
+        String arn = validateSecretId(secretId);
         try {
-            arn = validateSecretId(secretId);
             if (refreshSecret && Utils.isEmpty(versionId)) {
                 refreshSecretFromCloud(arn, versionStage);
             }

--- a/src/test/java/com/aws/greengrass/secretmanager/SecretManagerTest.java
+++ b/src/test/java/com/aws/greengrass/secretmanager/SecretManagerTest.java
@@ -596,7 +596,7 @@ class SecretManagerTest {
         try {
             sm.getSecret(request);
         } catch (GetSecretException e) {
-            assertEquals("Secret not found " + SECRET_NAME_1, e.getMessage());
+            assertEquals("Secret not configured " + SECRET_NAME_1, e.getMessage());
             assertEquals(404, e.getStatus());
         }
     }
@@ -780,26 +780,6 @@ class SecretManagerTest {
         } catch (GetSecretException response) {
             assertEquals(400, response.getStatus());
             assertEquals("SecretId absent in the request", response.getMessage());
-        }
-
-        // Create a request for secret which is not present
-        request = new software.amazon.awssdk.aws.greengrass.model.GetSecretValueRequest();
-        request.setSecretId(SECRET_NAME_1);
-        try {
-            sm.getSecret(request);
-        } catch (GetSecretException response) {
-            assertEquals(404, response.getStatus());
-            assertEquals("Secret not found " + SECRET_NAME_1, response.getMessage());
-        }
-
-        // Create a request for secret arn which is not present
-        request = new software.amazon.awssdk.aws.greengrass.model.GetSecretValueRequest();
-        request.setSecretId(ARN_1);
-        try {
-            sm.getSecret(request);
-        } catch (GetSecretException response) {
-            assertEquals(404, response.getStatus());
-            assertEquals("Secret not found " + ARN_1, response.getMessage());
         }
 
         // Actually load the secrets


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Check for version stage when deciding if secret needs to to be refreshed from cloud. Not defining a version stage as part of an IPC request is fine and Secret Manager should just fall back to the `AWSCURRENT` label.

Also, removed some stale unit tests. The removal mostly revolves around secret not present in the cache. With the latest changes, if a secret is configured but not present in the cache, Secret Manager will fetch the secret from cloud.

**Why is this change necessary:**
Version stage is an optional parameter in the IPC request and Secret Manager should refresh secret even if this parameter is absent.

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
