### PR TITLE
chore: do not retry when security service is unavailable

### DIFF
--- a/src/main/java/com/aws/greengrass/secretmanager/SecretManager.java
+++ b/src/main/java/com/aws/greengrass/secretmanager/SecretManager.java
@@ -204,6 +204,12 @@ public class SecretManager {
         }
     }
 
+    /*
+    In case device is offline or device security service is unavailable, refreshSecretFromCloud will catch the
+    exception, log the error and continue. The expectation is that the device may come online or device security
+    service becomes available eventually. If refreshSecretFromCloud is being called in a loop then the loop should not
+    exit entirely.
+     */
     private void refreshSecretFromCloud(String arn, String versionStage) {
         String versionLabel = Utils.isEmpty(versionStage) ? LATEST_LABEL : versionStage;
         List<SecretConfiguration> configurations = getSecretConfiguration();

--- a/src/test/java/com/aws/greengrass/secretmanager/SecretManagerTest.java
+++ b/src/test/java/com/aws/greengrass/secretmanager/SecretManagerTest.java
@@ -136,7 +136,7 @@ class SecretManagerTest {
     @Captor
     ArgumentCaptor<software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest> awsClientRequestCaptor;
 
-    private void loadMockSecrets() throws JsonProcessingException, UnsupportedInputTypeException {
+    private void loadMockSecrets() throws UnsupportedInputTypeException {
         SecretConfiguration secret1 = SecretConfiguration.builder().arn(ARN_1).build();
         SecretConfiguration secret2 = SecretConfiguration.builder().arn(ARN_2)
                 .labels(Arrays.asList(LATEST_LABEL, SECRET_LABEL_1)).build();


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Do not retry loading crypter if underlying security service is unavailable.

**Why is this change necessary:**
During the initial sync with cloud, when encrypting downloaded secrets, Secret Manager attempts to load crypter from the underlying security service with retry. This retry is a blocking call until max number of retries (10) are hit. Since, we are already refreshing a secret from cloud automatically if that secret is absent from the local cache, this blocking retry is not required.

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
